### PR TITLE
Implement month/year tracking with top bar

### DIFF
--- a/Assets/Script/ControlPanel.cs
+++ b/Assets/Script/ControlPanel.cs
@@ -18,6 +18,7 @@ public class ControlPanel : MonoBehaviour
     private Label woodLabel;
     private Label foodLabel;
     private Label cronoLabel;
+    private Label dateLabel;
     void OnEnable()
     {
         Instance = this;
@@ -29,6 +30,9 @@ public class ControlPanel : MonoBehaviour
         woodLabel = root.Q<Label>("WoodLabel");
         foodLabel = root.Q<Label>("FoodLabel");
         cronoLabel = root.Q<Label>("CronoLabel");
+        dateLabel = uiDocument.rootVisualElement.Q<Label>("DateLabel");
+        GameTimeManager.OnDateChanged += UpdateDateLabel;
+        UpdateDateLabel(GameTimeManager.CurrentMonth, GameTimeManager.CurrentYear);
         RegisterClickBlocker();
         UpdateResourceLabels();
         GameEvents.OnSelectionChanged += UpdatePanel;
@@ -36,6 +40,7 @@ public class ControlPanel : MonoBehaviour
     void OnDisable()
     {
         GameEvents.OnSelectionChanged -= UpdatePanel;
+        GameTimeManager.OnDateChanged -= UpdateDateLabel;
     }
     void Update()
     {
@@ -305,6 +310,12 @@ public class ControlPanel : MonoBehaviour
         if (woodLabel != null) woodLabel.text = $"Madera: {res.wood}";
         if (foodLabel != null) foodLabel.text = $"Comida: {res.food}";
         if (cronoLabel != null) cronoLabel.text = $"Crono: {res.crono}";
+    }
+
+    void UpdateDateLabel(int month, int year)
+    {
+        if (dateLabel != null)
+            dateLabel.text = $"Mes {month} - Año {year}";
     }
 
 

--- a/Assets/Script/GameTimeManager.cs
+++ b/Assets/Script/GameTimeManager.cs
@@ -3,7 +3,20 @@ using UnityEngine;
 public class GameTimeManager : MonoBehaviour
 {
     public float interval = 5f; // cada 5 segundos
+    public int cyclesPerMonth = 30;
+
     private float timer = 0f;
+    private int currentCycle = 0;
+
+    public static int CurrentMonth { get; private set; } = 1;
+    public static int CurrentYear { get; private set; } = 1;
+
+    public static event System.Action<int, int> OnDateChanged;
+
+    void Start()
+    {
+        OnDateChanged?.Invoke(CurrentMonth, CurrentYear);
+    }
 
     void Update()
     {
@@ -11,6 +24,7 @@ public class GameTimeManager : MonoBehaviour
         if (timer >= interval)
         {
             ApplyResourceFlow();
+            AdvanceCycle();
             timer = 0f;
         }
     }
@@ -34,5 +48,22 @@ public class GameTimeManager : MonoBehaviour
         }
 
         GameState.playerResources.AddFlow(total);
+    }
+
+    void AdvanceCycle()
+    {
+        currentCycle++;
+        if (currentCycle >= cyclesPerMonth)
+        {
+            currentCycle = 0;
+            CurrentMonth++;
+            if (CurrentMonth > 12)
+            {
+                CurrentMonth = 1;
+                CurrentYear++;
+            }
+
+            OnDateChanged?.Invoke(CurrentMonth, CurrentYear);
+        }
     }
 }

--- a/Assets/UI Toolkit/ControlPanel.uss
+++ b/Assets/UI Toolkit/ControlPanel.uss
@@ -13,6 +13,22 @@
 
 }
 
+.date-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 24px;
+    background-color: rgba(0, 0, 0, 0.6);
+    justify-content: center;
+    align-items: center;
+}
+
+.date-bar .unity-label {
+    color: white;
+    font-size: 14px;
+}
+
 .panel-column {
     flex-grow: 1;
     flex-direction: column;

--- a/Assets/UI Toolkit/ControlPanel.uxml
+++ b/Assets/UI Toolkit/ControlPanel.uxml
@@ -1,5 +1,8 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" editor-extension-mode="True">
     <Style src="project://database/Assets/UI%20Toolkit/ControlPanel.uss?fileID=7433441132597879392&amp;guid=fc6db9428fb7f694dac375997d165b80&amp;type=3#ControlPanel" />
+    <ui:VisualElement name="dateBar" class="date-bar">
+        <ui:Label name="DateLabel" text="Mes 1 - Año 1" />
+    </ui:VisualElement>
     <ui:VisualElement name="root" class="panel-root">
         <ui:VisualElement class="panel-column resources-panel">
             <ui:Label name="GoldLabel" text="Oro: 0" />


### PR DESCRIPTION
## Summary
- extend `GameTimeManager` with cycle-based calendar and event
- show current date in a new top bar inside the existing UI document
- update `ControlPanel` to display the month and year

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883dcfce7a483339746f68eccf2fb9d