### PR TITLE
Add worker-based resource allocation

### DIFF
--- a/Assets/Script/GameTimeManager.cs
+++ b/Assets/Script/GameTimeManager.cs
@@ -33,18 +33,67 @@ public class GameTimeManager : MonoBehaviour
     {
         var total = new ResourceFlow();
 
+        int farmCount = 0;
+        int mineCount = 0;
+        int lumberCount = 0;
+
         foreach (var cell in MapState.cellMap.Values)
         {
-            if (!string.IsNullOrEmpty(cell.building))
+            if (string.IsNullOrEmpty(cell.building))
+                continue;
+
+            switch (cell.building)
             {
-                total += ResourceProductionMatrix.GetFlow(cell.building);
+                case "farm":
+                    farmCount++;
+                    break;
+                case "mine":
+                    mineCount++;
+                    break;
+                case "lumbermill":
+                    lumberCount++;
+                    break;
+                default:
+                    total += ResourceProductionMatrix.GetFlow(cell.building);
+                    break;
             }
         }
+
+        int availableWorkers = 0;
 
         foreach (var character in GameObject.FindObjectsOfType<Character>())
         {
             string unitCode = character.characterType.ToString().ToLower();
             total += ResourceProductionMatrix.GetFlow(unitCode);
+
+            if (character.characterType == Character.Type.Worker &&
+                character.controlMode == Character.ControlMode.Automatic &&
+                character.currentTask == Character.Task.None)
+            {
+                availableWorkers++;
+            }
+        }
+
+        int totalWeight = farmCount + mineCount + lumberCount;
+        float goldWorkers = 0f;
+        float woodWorkers = 0f;
+        float foodWorkers = 0f;
+
+        if (totalWeight > 0 && availableWorkers > 0)
+        {
+            goldWorkers = availableWorkers * (mineCount / (float)totalWeight);
+            woodWorkers = availableWorkers * (lumberCount / (float)totalWeight);
+            foodWorkers = availableWorkers * (farmCount / (float)totalWeight);
+
+            goldWorkers = Mathf.Min(goldWorkers, mineCount);
+            woodWorkers = Mathf.Min(woodWorkers, lumberCount);
+            foodWorkers = Mathf.Min(foodWorkers, farmCount);
+
+            var mineFlow = ResourceProductionMatrix.GetFlow("mine").Scale(goldWorkers);
+            var lumberFlow = ResourceProductionMatrix.GetFlow("lumbermill").Scale(woodWorkers);
+            var farmFlow = ResourceProductionMatrix.GetFlow("farm").Scale(foodWorkers);
+
+            total += mineFlow + lumberFlow + farmFlow;
         }
 
         GameState.playerResources.AddFlow(total);

--- a/Assets/Script/ResourceFlow.cs
+++ b/Assets/Script/ResourceFlow.cs
@@ -15,6 +15,16 @@ public class ResourceFlow
         this.crono = crono;
     }
 
+    public ResourceFlow Scale(float factor)
+    {
+        return new ResourceFlow(
+            Mathf.RoundToInt(gold * factor),
+            Mathf.RoundToInt(wood * factor),
+            Mathf.RoundToInt(food * factor),
+            Mathf.RoundToInt(crono * factor)
+        );
+    }
+
     public static ResourceFlow operator +(ResourceFlow a, ResourceFlow b) =>
         new ResourceFlow(a.gold + b.gold, a.wood + b.wood, a.food + b.food, a.crono + b.crono);
 }


### PR DESCRIPTION
## Summary
- allow scaling `ResourceFlow` with a float factor
- allocate idle automatic workers to resources based on building counts
- scale farm, mine and lumbermill production by assigned workers

## Testing
- `no tests run`

------
https://chatgpt.com/codex/tasks/task_e_6883e4345b508333b47dcbf1c62f219f