### PR TITLE
Use role components for character types

### DIFF
--- a/Assets/Script/BuildRules.cs
+++ b/Assets/Script/BuildRules.cs
@@ -73,6 +73,11 @@ public static class BuildRules
         };
     }
 
+    public static BuildRequirement GetRequirements(CharacterRole role)
+    {
+        return GetRequirements(role.Code);
+    }
+
 
     public static BuildRequirement TakeRequirements(string code)
     {
@@ -95,5 +100,10 @@ public static class BuildRules
             Character.Type.Scientist => TakeRequirements("scientist"),
             _ => new BuildRequirement()
         };
+    }
+
+    public static BuildRequirement TakeRequirements(CharacterRole role)
+    {
+        return TakeRequirements(role.Code);
     }
 }

--- a/Assets/Script/Character.cs
+++ b/Assets/Script/Character.cs
@@ -6,6 +6,7 @@ public class Character : MonoBehaviour
 {
     public enum Type { Worker, Scientist, Warrior }
     public Type characterType;
+    public CharacterRole role;
     public string owner;
 
     private Vector3 targetPosition;
@@ -42,11 +43,27 @@ public class Character : MonoBehaviour
     public void Init(Type type, string ownerId)
     {
         characterType = type;
+        role = GetComponent<CharacterRole>();
         owner = ownerId;
         name = $"{type}_{owner}";
         targetPosition = transform.position;
 
         // Asignar automáticamente el SpriteRenderer si no está asignado
+        if (spriteRenderer == null)
+            spriteRenderer = GetComponent<SpriteRenderer>();
+
+        animator = GetComponent<CharacterAnimator>();
+
+        SetIdleSprite();
+    }
+
+    public void Init(CharacterRole roleComponent, string ownerId)
+    {
+        role = roleComponent;
+        owner = ownerId;
+        name = $"{roleComponent.Code}_{owner}";
+        targetPosition = transform.position;
+
         if (spriteRenderer == null)
             spriteRenderer = GetComponent<SpriteRenderer>();
 

--- a/Assets/Script/CharacterController.cs
+++ b/Assets/Script/CharacterController.cs
@@ -131,7 +131,7 @@ public class CharacterController : MonoBehaviour
             selectedCharacter.SetPath(path);
 
         // Mostrar opciones si es trabajador y se puede construir allí
-        if (selectedCharacter.characterType == Character.Type.Worker
+        if (selectedCharacter.role is WorkerRole
             && MapState.cellMap.TryGetValue(gridPos, out var cell)
             && string.IsNullOrEmpty(cell.building))
         {

--- a/Assets/Script/CharacterRole.cs
+++ b/Assets/Script/CharacterRole.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public abstract class CharacterRole : MonoBehaviour
+{
+    public abstract string Code { get; }
+}

--- a/Assets/Script/CharacterRole.cs.meta
+++ b/Assets/Script/CharacterRole.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c71c654cc2854f77a8e203fa60b54f97

--- a/Assets/Script/ControlPanel.cs
+++ b/Assets/Script/ControlPanel.cs
@@ -58,13 +58,14 @@ public class ControlPanel : MonoBehaviour
             title.text = character.name;
             buttons.Clear();
 
-            if (character.characterType == Character.Type.Warrior)
+            if (character.role is WarriorRole)
                 AddButton("Atacar", () => GameEvents.RequestAttack(character));
 
-            if (character.characterType == Character.Type.Scientist)
+            if (character.role is ScientistRole)
                 AddButton("Curar", () => GameEvents.RequestHeal(character));
 
-            info.Add(new Label($"Tipo: {character.characterType}"));
+            string typeName = character.role != null ? character.role.Code : character.characterType.ToString();
+            info.Add(new Label($"Tipo: {typeName}"));
             info.Add(new Label($"Control: {character.controlMode}"));
             info.Add(new Label($"Dueño: {character.owner}"));
 

--- a/Assets/Script/GameTimeManager.cs
+++ b/Assets/Script/GameTimeManager.cs
@@ -75,10 +75,12 @@ public class GameTimeManager : MonoBehaviour
 
         foreach (var character in GameObject.FindObjectsOfType<Character>())
         {
-            string unitCode = character.characterType.ToString().ToLower();
-            total += ResourceProductionMatrix.GetFlow(unitCode);
+            if (character.role != null)
+                total += ResourceProductionMatrix.GetFlow(character.role);
+            else
+                total += ResourceProductionMatrix.GetFlow(character.characterType.ToString().ToLower());
 
-            if (character.characterType == Character.Type.Worker)
+            if (character.role is WorkerRole)
             {
                 if (character.currentTask == Character.Task.None)
                 {

--- a/Assets/Script/MapLoader.cs
+++ b/Assets/Script/MapLoader.cs
@@ -361,6 +361,7 @@ public class MapLoader : MonoBehaviour
 
 
         // Asignar sprites al animator
+        CharacterRole role = null;
         if (type == Character.Type.Worker && animator != null)
         {
             go.tag = "Worker";
@@ -369,6 +370,7 @@ public class MapLoader : MonoBehaviour
             animator.southSprites = workerSouthSprites;
             animator.eastSprites = workerEastSprites;
             animator.westSprites = workerWestSprites;
+            role = go.AddComponent<WorkerRole>();
         }
         if (type == Character.Type.Scientist && animator != null)
         {
@@ -378,6 +380,7 @@ public class MapLoader : MonoBehaviour
             animator.southSprites = scientistSouthSprites;
             animator.eastSprites = scientistEastSprites;
             animator.westSprites = scientistWestSprites;
+            role = go.AddComponent<ScientistRole>();
         }
         if (type == Character.Type.Warrior && animator != null)
         {
@@ -387,6 +390,7 @@ public class MapLoader : MonoBehaviour
             animator.southSprites = warriorSouthSprites;
             animator.eastSprites = warriorEastSprites;
             animator.westSprites = warriorWestSprites;
+            role = go.AddComponent<WarriorRole>();
         }
         character.LoadSprites(new Dictionary<string, Sprite[]>
             {
@@ -397,7 +401,10 @@ public class MapLoader : MonoBehaviour
             });
 
 
-        character.Init(type, owner);
+        if (role != null)
+            character.Init(role, owner);
+        else
+            character.Init(type, owner);
 
         go.transform.LookAt(Camera.main.transform);
         go.transform.rotation = Quaternion.Euler(0, go.transform.rotation.eulerAngles.y, 0);

--- a/Assets/Script/ResourceProductionMatrix.cs
+++ b/Assets/Script/ResourceProductionMatrix.cs
@@ -18,4 +18,9 @@ public static class ResourceProductionMatrix
     {
         return production.TryGetValue(code, out var flow) ? flow : new ResourceFlow();
     }
+
+    public static ResourceFlow GetFlow(CharacterRole role)
+    {
+        return GetFlow(role.Code);
+    }
 }

--- a/Assets/Script/ScientistRole.cs
+++ b/Assets/Script/ScientistRole.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class ScientistRole : CharacterRole
+{
+    public override string Code => "scientist";
+}

--- a/Assets/Script/ScientistRole.cs.meta
+++ b/Assets/Script/ScientistRole.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62840cec1c9340bd8cf1b23ea8471612

--- a/Assets/Script/TileActionProvider.cs
+++ b/Assets/Script/TileActionProvider.cs
@@ -115,7 +115,7 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
         var all = GameObject.FindObjectsOfType<Character>();
         foreach (var c in all)
         {
-            if (c.characterType == Character.Type.Worker &&
+            if (c.role is WorkerRole &&
                 c.controlMode == Character.ControlMode.Automatic &&
                 c.currentTask == Character.Task.None)
             {
@@ -124,7 +124,7 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
         }
         foreach (var c in all)
         {
-            if (c.characterType == Character.Type.Worker &&
+            if (c.role is WorkerRole &&
                 c.controlMode == Character.ControlMode.Manual &&
                 c.currentTask == Character.Task.None)
             {

--- a/Assets/Script/WarriorRole.cs
+++ b/Assets/Script/WarriorRole.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class WarriorRole : CharacterRole
+{
+    public override string Code => "warrior";
+}

--- a/Assets/Script/WarriorRole.cs.meta
+++ b/Assets/Script/WarriorRole.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0824424ab7ad422696216ac1d52c012b

--- a/Assets/Script/WorkerRole.cs
+++ b/Assets/Script/WorkerRole.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class WorkerRole : CharacterRole
+{
+    public override string Code => "worker";
+}

--- a/Assets/Script/WorkerRole.cs.meta
+++ b/Assets/Script/WorkerRole.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19ed645401354f23955b8cd7baf69ef1


### PR DESCRIPTION
## Summary
- add `CharacterRole` base component and specific roles
- update `Character` to store role and initialize from components
- spawn characters with role components
- expose role-based checks in control panel, controller, build rules, resource matrix, and time manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688761db3e1883338e1b883500a8d250