### PR TITLE
Delegate actions to character roles

### DIFF
--- a/Assets/Script/Character.cs
+++ b/Assets/Script/Character.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using static DTO;
 
-public class Character : MonoBehaviour
+public class Character : MonoBehaviour, IActionProposer
 {
     public enum Type { Worker, Scientist, Warrior }
     public Type characterType;
@@ -357,5 +357,10 @@ public void AssignBuildTask(Vector2Int pos, string building)
         currentPath = null;
         moving = false;
         gatherRoute = null;
+    }
+
+    public void ProposeActions(GamePlayer player)
+    {
+        role?.ProposeActions(this, player);
     }
 }

--- a/Assets/Script/CharacterRole.cs
+++ b/Assets/Script/CharacterRole.cs
@@ -3,4 +3,8 @@ using UnityEngine;
 public abstract class CharacterRole : MonoBehaviour
 {
     public abstract string Code { get; }
+
+    public virtual void ProposeActions(Character character, GamePlayer player)
+    {
+    }
 }

--- a/Assets/Script/ControlPanel.cs
+++ b/Assets/Script/ControlPanel.cs
@@ -58,12 +58,6 @@ public class ControlPanel : MonoBehaviour
             title.text = character.name;
             buttons.Clear();
 
-            if (character.role is WarriorRole)
-                AddButton("Atacar", () => GameEvents.RequestAttack(character));
-
-            if (character.role is ScientistRole)
-                AddButton("Curar", () => GameEvents.RequestHeal(character));
-
             string typeName = character.role != null ? character.role.Code : character.characterType.ToString();
             info.Add(new Label($"Tipo: {typeName}"));
             info.Add(new Label($"Control: {character.controlMode}"));
@@ -73,10 +67,17 @@ public class ControlPanel : MonoBehaviour
             {
                 info.Add(new Label($"Salud: {health.currentHealth}/{health.maxHealth}"));
             }
+
+            GamePlayer.Instance.Clear();
+            character.ProposeActions(GamePlayer.Instance);
+            foreach (var act in GamePlayer.Instance.GetActions())
+            {
+                AddButton(act.label, act.callback);
+            }
         }
 
         var tileProvider = selected.GetComponent<IActionProposer>();
-        if (tileProvider != null)
+        if (tileProvider != null && character == null)
         {
             var handler = selected.GetComponent<TileClickHandler>();
             if (handler != null)

--- a/Assets/Script/ScientistRole.cs
+++ b/Assets/Script/ScientistRole.cs
@@ -3,4 +3,12 @@ using UnityEngine;
 public class ScientistRole : CharacterRole
 {
     public override string Code => "scientist";
+
+    public override void ProposeActions(Character character, GamePlayer player)
+    {
+        player.AddAction(new ControlPanelAction("Curar", () =>
+        {
+            GameEvents.RequestHeal(character);
+        }));
+    }
 }

--- a/Assets/Script/WarriorRole.cs
+++ b/Assets/Script/WarriorRole.cs
@@ -3,4 +3,12 @@ using UnityEngine;
 public class WarriorRole : CharacterRole
 {
     public override string Code => "warrior";
+
+    public override void ProposeActions(Character character, GamePlayer player)
+    {
+        player.AddAction(new ControlPanelAction("Atacar", () =>
+        {
+            GameEvents.RequestAttack(character);
+        }));
+    }
 }


### PR DESCRIPTION
## Summary
- centralize character action creation via `IActionProposer`
- allow each `CharacterRole` to propose its own actions
- update `WarriorRole` and `ScientistRole` to add "Atacar" and "Curar"
- modify `ControlPanel` to use the character's `ProposeActions` method

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688764620f40833395eb5536ab60ec20