### PR TITLE
Implement info via double dispatch

### DIFF
--- a/Assets/Script/ActionManager.cs
+++ b/Assets/Script/ActionManager.cs
@@ -11,6 +11,10 @@ public class ActionManager : MonoBehaviour
     {
         return true; // placeholder for extra rules
     }
+    public bool Approve(InfoItem info)
+    {
+        return true; // placeholder for extra rules
+    }
     void Awake()
     {
         Instance = this;

--- a/Assets/Script/Character.cs
+++ b/Assets/Script/Character.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using static DTO;
 
-public class Character : MonoBehaviour, IActionProposer
+public class Character : MonoBehaviour, IActionProposer, IInfoProvider
 {
     public enum Type { Worker, Scientist, Warrior }
     public Type characterType;
@@ -362,5 +362,18 @@ public void AssignBuildTask(Vector2Int pos, string building)
     public void ProposeActions(GamePlayer player)
     {
         role?.ProposeActions(this, player);
+    }
+
+    public void ProvideInfo(GamePlayer player)
+    {
+        string typeName = role != null ? role.Code : characterType.ToString();
+        player.AddInfo(new InfoItem($"Tipo: {typeName}", "detail"));
+        player.AddInfo(new InfoItem($"Control: {controlMode}", "detail"));
+        player.AddInfo(new InfoItem($"Dueño: {owner}", "detail"));
+
+        if (TryGetComponent(out HealthComponent health))
+        {
+            player.AddInfo(new InfoItem($"Salud: {health.currentHealth}/{health.maxHealth}", "status"));
+        }
     }
 }

--- a/Assets/Script/ControlPanel.cs
+++ b/Assets/Script/ControlPanel.cs
@@ -13,6 +13,7 @@ public class ControlPanel : MonoBehaviour
     private VisualElement buttons;
     private Label title;
     private VisualElement info;
+    private VisualElement resourceInfo;
     public static ControlPanel Instance { get; private set; }
 
     private Label goldLabel;
@@ -29,11 +30,17 @@ public class ControlPanel : MonoBehaviour
         buttons = root.Q<VisualElement>("buttons");
         title = root.Q<Label>("InfoTitle");
         info = root.Q<VisualElement>("info");
+        resourceInfo = root.Q<VisualElement>(className: "resources-panel");
         goldLabel = root.Q<Label>("GoldLabel");
         woodLabel = root.Q<Label>("WoodLabel");
         foodLabel = root.Q<Label>("FoodLabel");
         cronoLabel = root.Q<Label>("CronoLabel");
         dateLabel = uiDocument.rootVisualElement.Q<Label>("DateLabel");
+        if (resourceInfo != null)
+        {
+            resourceInfo.Add(new VisualElement { name = "SelectedResourceInfo" });
+            resourceInfo = resourceInfo.Q<VisualElement>("SelectedResourceInfo");
+        }
         GameTimeManager.OnDateChanged += UpdateDateLabel;
         UpdateDateLabel(GameTimeManager.CurrentMonth, GameTimeManager.CurrentYear);
         RegisterClickBlocker();
@@ -52,24 +59,19 @@ public class ControlPanel : MonoBehaviour
     void UpdatePanel(GameObject selected)
     {
         info.Clear();
+        resourceInfo?.Clear();
+        GamePlayer.Instance.Clear();
         var character = selected.GetComponent<Character>();
         if (character != null)
         {
             title.text = character.name;
             buttons.Clear();
-
-            string typeName = character.role != null ? character.role.Code : character.characterType.ToString();
-            info.Add(new Label($"Tipo: {typeName}"));
-            info.Add(new Label($"Control: {character.controlMode}"));
-            info.Add(new Label($"Dueño: {character.owner}"));
-
-            if (character.TryGetComponent(out HealthComponent health))
-            {
-                info.Add(new Label($"Salud: {health.currentHealth}/{health.maxHealth}"));
-            }
-
-            GamePlayer.Instance.Clear();
+            character.ProvideInfo(GamePlayer.Instance);
             character.ProposeActions(GamePlayer.Instance);
+            foreach (var infoItem in GamePlayer.Instance.GetInfo())
+            {
+                AddInfoLabel(infoItem);
+            }
             foreach (var act in GamePlayer.Instance.GetActions())
             {
                 AddButton(act.label, act.callback);
@@ -84,21 +86,14 @@ public class ControlPanel : MonoBehaviour
             {
                 var cell = handler.GetCellData();
                 title.text = $"Tile ({cell.x}, {cell.y})";
-                info.Clear();
-                if (cell.resources != null)
+                handler.ProvideInfo(GamePlayer.Instance);
+                foreach (var infoItem in GamePlayer.Instance.GetInfo())
                 {
-                    info.Add(new Label($"Oro: {cell.resources.gold}"));
-                    info.Add(new Label($"Madera: {cell.resources.wood}"));
-                    info.Add(new Label($"Crono: {cell.resources.crono}"));
-                }
-                if (!string.IsNullOrEmpty(cell.building))
-                {
-                    info.Add(new Label($"Construcción existente: {cell.building}"));
+                    AddInfoLabel(infoItem);
                 }
             }
 
             buttons.Clear();
-            GamePlayer.Instance.Clear();
             tileProvider.ProposeActions(GamePlayer.Instance);
             foreach (var act in GamePlayer.Instance.GetActions())
             {
@@ -163,6 +158,14 @@ public class ControlPanel : MonoBehaviour
         button.pickingMode = PickingMode.Position;
 
         buttons.Add(button);
+    }
+
+    void AddInfoLabel(InfoItem item)
+    {
+        if (item.type == "resource" && resourceInfo != null)
+            resourceInfo.Add(new Label(item.label));
+        else
+            info.Add(new Label(item.label));
     }
 
     void RegisterClickBlocker()

--- a/Assets/Script/GamePlayer.cs
+++ b/Assets/Script/GamePlayer.cs
@@ -6,6 +6,7 @@ public class GamePlayer : MonoBehaviour
     public static GamePlayer Instance { get; private set; }
 
     private readonly List<ControlPanelAction> collected = new();
+    private readonly List<InfoItem> infoCollected = new();
 
     void Awake()
     {
@@ -15,6 +16,7 @@ public class GamePlayer : MonoBehaviour
     public void Clear()
     {
         collected.Clear();
+        infoCollected.Clear();
     }
 
     public void AddAction(ControlPanelAction action)
@@ -26,8 +28,22 @@ public class GamePlayer : MonoBehaviour
         collected.Add(action);
     }
 
+    public void AddInfo(InfoItem info)
+    {
+        if (GameTimeManager.Instance != null && !GameTimeManager.Instance.Approve(info))
+            return;
+        if (ActionManager.Instance != null && !ActionManager.Instance.Approve(info))
+            return;
+        infoCollected.Add(info);
+    }
+
     public IEnumerable<ControlPanelAction> GetActions()
     {
         return collected;
+    }
+
+    public IEnumerable<InfoItem> GetInfo()
+    {
+        return infoCollected;
     }
 }

--- a/Assets/Script/GameTimeManager.cs
+++ b/Assets/Script/GameTimeManager.cs
@@ -192,4 +192,9 @@ public class GameTimeManager : MonoBehaviour
     {
         return true; // placeholder for time-based rules
     }
+
+    public bool Approve(InfoItem info)
+    {
+        return true; // placeholder for time-based rules
+    }
 }

--- a/Assets/Script/IInfoProvider.cs
+++ b/Assets/Script/IInfoProvider.cs
@@ -1,0 +1,4 @@
+public interface IInfoProvider
+{
+    void ProvideInfo(GamePlayer player);
+}

--- a/Assets/Script/IInfoProvider.cs.meta
+++ b/Assets/Script/IInfoProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6a0c2cbb0c1424cbbe66e0b0bac0d77

--- a/Assets/Script/InfoItem.cs
+++ b/Assets/Script/InfoItem.cs
@@ -1,0 +1,10 @@
+public class InfoItem
+{
+    public string label;
+    public string type;
+    public InfoItem(string label, string type)
+    {
+        this.label = label;
+        this.type = type;
+    }
+}

--- a/Assets/Script/InfoItem.cs.meta
+++ b/Assets/Script/InfoItem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3a5f463bb9d45fda2e331b4f395aabc

--- a/Assets/Script/TileClickHandler.cs
+++ b/Assets/Script/TileClickHandler.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using static DTO;
 
-public class TileClickHandler : MonoBehaviour
+public class TileClickHandler : MonoBehaviour, IInfoProvider
 {
     private MapCellDTO cellData;
     public GameObject previewObject;
@@ -23,5 +23,25 @@ public class TileClickHandler : MonoBehaviour
     public MapCellDTO GetCellData()
     {
         return cellData;
+    }
+
+    public void ProvideInfo(GamePlayer player)
+    {
+        if (cellData == null) return;
+
+        if (cellData.resources != null)
+        {
+            if (cellData.resources.gold > 0)
+                player.AddInfo(new InfoItem($"Oro: {cellData.resources.gold}", "resource"));
+            if (cellData.resources.wood > 0)
+                player.AddInfo(new InfoItem($"Madera: {cellData.resources.wood}", "resource"));
+            if (cellData.resources.crono > 0)
+                player.AddInfo(new InfoItem($"Crono: {cellData.resources.crono}", "resource"));
+        }
+
+        if (!string.IsNullOrEmpty(cellData.building))
+        {
+            player.AddInfo(new InfoItem($"Construcción existente: {cellData.building}", "detail"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `InfoItem` and `IInfoProvider` for information dispatch
- extend `GamePlayer` to collect info items
- allow `ActionManager` and `GameTimeManager` to approve info
- implement info providers on `Character` and `TileClickHandler`
- update `ControlPanel` to request info from providers and display it

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887677813c88333ab1a8dd50f6e29eb