### PR TITLE
Remove starting townhalls

### DIFF
--- a/Assets/Resources/map_data.json
+++ b/Assets/Resources/map_data.json
@@ -261,7 +261,7 @@
             "resources": {
                 "gold": 0,
                 "wood": 37,
-                "crono": 0
+                "crono": 1
             }
         },
         {
@@ -465,7 +465,7 @@
             "resources": {
                 "gold": 0,
                 "wood": 34,
-                "crono": 0
+                "crono": 1
             }
         },
         {
@@ -4341,7 +4341,7 @@
             "resources": {
                 "gold": 0,
                 "wood": 19,
-                "crono": 0
+                "crono": 1
             }
         },
         {
@@ -4545,7 +4545,7 @@
             "resources": {
                 "gold": 0,
                 "wood": 17,
-                "crono": 0
+                "crono": 1
             }
         },
         {

--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -186,6 +186,10 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 for (int i = 1; i < segment.Count; i++) route.Add(segment[i]);
                 segment = Pathfinder.FindPath(tree, lumber, MapState.cellMap);
                 for (int i = 1; i < segment.Count; i++) route.Add(segment[i]);
+                segment = Pathfinder.FindPath(lumber, townhall, MapState.cellMap);
+                for (int i = 1; i < segment.Count; i++) route.Add(segment[i]);
+                segment = Pathfinder.FindPath(townhall, lumber, MapState.cellMap);
+                for (int i = 1; i < segment.Count; i++) route.Add(segment[i]);
                 break;
             case Character.GatherTask.Food:
                 Vector2Int farm = FindNearest(start, c => c.building == "farm");
@@ -251,6 +255,15 @@ public void AssignBuildTask(Vector2Int pos, string building)
             MapLoader.instance.DrawBuilding(pos, building); // <- 🔥 Dibuja en el tile
             Debug.Log($"{name} construyó {building} en {pos}");
             MapLoader.instance.ClearConstructionPreview(pos);
+
+            if (building == "townhall")
+            {
+                foreach (var c in GameObject.FindObjectsOfType<Character>())
+                {
+                    if (c.role is WorkerRole && c.owner == owner)
+                        c.PlanGatherRoute();
+                }
+            }
 
             GameEvents.RaiseSelection(gameObject);
         }


### PR DESCRIPTION
## Summary
- stop placing townhalls automatically at player spawn positions so their location isn't known until built
- previous changes still allow workers to replan routes when a townhall is constructed

## Testing
- `git log -1 --stat`
- `grep -n "crono":\ 1 Assets/Resources/map_data.json | head`

------
https://chatgpt.com/codex/tasks/task_e_6887833d6ea0833384c3cf2d4bd0592a