### PR TITLE
Define spawn points via map data

### DIFF
--- a/Assets/Resources/map_data.json
+++ b/Assets/Resources/map_data.json
@@ -258,6 +258,7 @@
             "terrain": "forest",
             "building": "",
             "owner": "",
+            "start_player": "player1",
             "resources": {
                 "gold": 0,
                 "wood": 37,
@@ -4542,6 +4543,7 @@
             "terrain": "forest",
             "building": "",
             "owner": "",
+            "start_player": "ai1",
             "resources": {
                 "gold": 0,
                 "wood": 17,

--- a/Assets/Script/Players/PlayerManager.cs
+++ b/Assets/Script/Players/PlayerManager.cs
@@ -26,13 +26,30 @@ public class PlayerManager : MonoBehaviour
     {
         players.Clear();
         if (playerCount < 1) playerCount = 1;
-        Vector2Int spawn = defaultSpawns.Length > 0 ? defaultSpawns[0] : new Vector2Int(1,1);
+
+        // buscar posiciones de inicio definidas en el mapa
+        Dictionary<string, Vector2Int> mapSpawns = new();
+        foreach (var kv in MapState.cellMap)
+        {
+            if (!string.IsNullOrEmpty(kv.Value.start_player))
+            {
+                mapSpawns[kv.Value.start_player] = kv.Key;
+            }
+        }
+
+        Vector2Int spawn = mapSpawns.ContainsKey("player1")
+            ? mapSpawns["player1"]
+            : (defaultSpawns.Length > 0 ? defaultSpawns[0] : new Vector2Int(1,1));
+
         players.Add(new HumanPlayer("player1", spawn));
 
         for (int i = 1; i < playerCount; i++)
         {
-            Vector2Int pos = i < defaultSpawns.Length ? defaultSpawns[i] : new Vector2Int(1 + i*2, 1 + i*2);
-            players.Add(new AIPlayer($"ai{i}", pos));
+            string id = $"ai{i}";
+            Vector2Int pos = mapSpawns.ContainsKey(id)
+                ? mapSpawns[id]
+                : (i < defaultSpawns.Length ? defaultSpawns[i] : new Vector2Int(1 + i*2, 1 + i*2));
+            players.Add(new AIPlayer(id, pos));
         }
 
         foreach (var p in players)

--- a/Assets/Script/World/DTO.cs
+++ b/Assets/Script/World/DTO.cs
@@ -11,6 +11,7 @@ public class DTO
         public string terrain;
         public string building;
         public string owner;
+        public string start_player;
         public ResourceBundle resources;
 
     }

--- a/Assets/Script/World/MapGenerator.cs
+++ b/Assets/Script/World/MapGenerator.cs
@@ -28,6 +28,12 @@ public class MapGenerator : MonoBehaviour
     {
         List<MapCellDTO> map = new();
 
+        Dictionary<Vector2Int, string> spawnPoints = new()
+        {
+            { new Vector2Int(1,1), "player1" },
+            { new Vector2Int(width-2, height-2), "ai1" }
+        };
+
         GenerateRivers();
         GenerateMountainClusters();
 
@@ -59,6 +65,8 @@ public class MapGenerator : MonoBehaviour
                     res.crono = 1;
                 }
 
+                string startId = spawnPoints.ContainsKey(pos) ? spawnPoints[pos] : null;
+
                 map.Add(new MapCellDTO
                 {
                     x = x,
@@ -66,6 +74,7 @@ public class MapGenerator : MonoBehaviour
                     terrain = terrain,
                     building = "",//buildings[Random.Range(0, buildings.Length)],
                     owner = "",//owners[Random.Range(0, owners.Length)],
+                    start_player = startId,
                     resources = res
                 });
 


### PR DESCRIPTION
## Summary
- extend `MapCellDTO` with `start_player` property
- read player spawn points from map data in `PlayerManager`
- mark two starting cells in `map_data.json`
- allow `MapGenerator` to place these start markers when generating maps

## Testing
- `grep -n "start_player" -n Assets/Resources/map_data.json`

------
https://chatgpt.com/codex/tasks/task_e_6887898e9f1883338f633e661102942d