### PR TITLE
Fix spawn position scaling

### DIFF
--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -338,7 +338,7 @@ public class MapLoader : MonoBehaviour
     public void SpawnCharacter(Vector2Int pos, Character.Type type, string owner)
     {
         GameObject go = Instantiate(characterPrefab);
-        go.transform.position = new Vector3(pos.x, 0.5f, pos.y);
+        go.transform.position = GridUtils.GridToWorld(pos);
         go.transform.localScale = Vector3.one;
 
         var character = go.GetComponent<Character>();


### PR DESCRIPTION
## Summary
- ensure characters spawn on proper grid positions by applying GridToWorld scale

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887aa30e6b88333b0b25228be5e29b6