### PR TITLE
Focus camera on player1 at start

### DIFF
--- a/Assets/Script/Players/PlayerManager.cs
+++ b/Assets/Script/Players/PlayerManager.cs
@@ -8,6 +8,7 @@ public class PlayerManager : MonoBehaviour
     public int playerCount = 2;
 
     private readonly List<Player> players = new();
+    public Vector2Int Player1Spawn { get; private set; }
 
     readonly Vector2Int[] defaultSpawns = new Vector2Int[]
     {
@@ -41,6 +42,7 @@ public class PlayerManager : MonoBehaviour
             ? mapSpawns["player1"]
             : (defaultSpawns.Length > 0 ? defaultSpawns[0] : new Vector2Int(1,1));
 
+        Player1Spawn = spawn;
         players.Add(new HumanPlayer("player1", spawn));
 
         for (int i = 1; i < playerCount; i++)
@@ -54,6 +56,10 @@ public class PlayerManager : MonoBehaviour
 
         foreach (var p in players)
             p.Initialize();
+
+        Vector3 focus = GridUtils.GridToWorld(Player1Spawn);
+        Camera.main.transform.position = focus + new Vector3(5, 10, -5);
+        Camera.main.transform.LookAt(focus);
     }
 
     void Update()


### PR DESCRIPTION
## Summary
- add Player1Spawn property
- after initializing players, position the camera on player1's spawn point

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b6a05ab8833399bdfbe84f5feeb5