### PR TITLE
Fix gather routing by owner

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -158,7 +158,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
     public void PlanGatherRoute()
     {
         Vector2Int start = this.GetGridPosition();
-        Vector2Int townhall = FindNearest(start, c => c.building == "townhall");
+        Vector2Int townhall = FindNearest(start, c => c.building == "townhall" && c.owner == owner);
         if (townhall.x < 0) return;
 
         List<Vector2Int> route = new();
@@ -166,7 +166,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
         switch (this.gatherTask)
         {
             case Character.GatherTask.Gold:
-                Vector2Int mine = FindNearest(start, c => c.building == "mine");
+                Vector2Int mine = FindNearest(start, c => c.building == "mine" && c.owner == owner);
                 if (mine.x < 0) return;
                 segment = Pathfinder.FindPath(start, mine, MapState.cellMap);
                 route.AddRange(segment);
@@ -176,7 +176,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 for (int i = 1; i < segment.Count; i++) route.Add(segment[i]);
                 break;
             case Character.GatherTask.Wood:
-                Vector2Int lumber = FindNearest(start, c => c.building == "lumbermill");
+                Vector2Int lumber = FindNearest(start, c => c.building == "lumbermill" && c.owner == owner);
                 if (lumber.x < 0) return;
                 Vector2Int tree = FindNearest(lumber, c => c.resources != null && c.resources.wood > 0);
                 if (tree.x < 0) return;
@@ -192,7 +192,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 for (int i = 1; i < segment.Count; i++) route.Add(segment[i]);
                 break;
             case Character.GatherTask.Food:
-                Vector2Int farm = FindNearest(start, c => c.building == "farm");
+                Vector2Int farm = FindNearest(start, c => c.building == "farm" && c.owner == owner);
                 if (farm.x < 0) return;
                 segment = Pathfinder.FindPath(start, farm, MapState.cellMap);
                 route.AddRange(segment);
@@ -251,6 +251,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 return;
             }
             cell.building = building;
+            cell.owner = owner;
             GameState.IncrementBuilding(building);
             MapLoader.instance.DrawBuilding(pos, building); // <- 🔥 Dibuja en el tile
             Debug.Log($"{name} construyó {building} en {pos}");


### PR DESCRIPTION
## Summary
- ensure buildings track which player built them
- workers now search for buildings owned by their player when planning gather routes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887e6b49c9083339d33f373c54d4e46