### PR TITLE
Adjust AI location search

### DIFF
--- a/Assets/Script/AI/AIManager.cs
+++ b/Assets/Script/AI/AIManager.cs
@@ -8,7 +8,7 @@ public class AIManager : MonoBehaviour
 
     void Start()
     {
-        ai = new BasicEnemyAI(enemyId);
+        ai = new BasicEnemyAI(enemyId, initialSpawn);
         if (MapLoader.instance != null)
             MapLoader.instance.SpawnCharacter(initialSpawn, Character.Type.Worker, enemyId);
     }

--- a/Assets/Script/AI/BasicEnemyAI.cs
+++ b/Assets/Script/AI/BasicEnemyAI.cs
@@ -5,15 +5,17 @@ using System.Linq;
 public class BasicEnemyAI
 {
     private readonly string ownerId;
+    private readonly Vector2Int spawnPosition;
     private float timer = 0f;
     private readonly float decisionInterval = 3f;
     
     private enum BuildPhase { NeedTownhall, NeedMine, Established }
     private BuildPhase currentPhase = BuildPhase.NeedTownhall;
 
-    public BasicEnemyAI(string owner)
+    public BasicEnemyAI(string owner, Vector2Int spawn)
     {
         ownerId = owner;
+        spawnPosition = spawn;
     }
 
     public void Update()
@@ -149,6 +151,10 @@ public class BasicEnemyAI
         float closestCrono = FindClosestResourceDistance(position, "crono");
         if (closestCrono < float.MaxValue)
             score += 50f / (1f + closestCrono * 0.5f);
+
+        // Preferir proximidad al punto de inicio del jugador
+        float spawnDist = Vector2Int.Distance(spawnPosition, position);
+        score += 50f / (1f + spawnDist * 0.5f);
         
         // Penalizar si está muy cerca del borde
         if (position.x < 2 || position.y < 2 || position.x > 18 || position.y > 18)

--- a/Assets/Script/Players/AIPlayer.cs
+++ b/Assets/Script/Players/AIPlayer.cs
@@ -6,7 +6,7 @@ public class AIPlayer : Player
 
     public AIPlayer(string id, Vector2Int spawn) : base(id, spawn)
     {
-        ai = new BasicEnemyAI(id);
+        ai = new BasicEnemyAI(id, spawn);
     }
 
     public override void Initialize()


### PR DESCRIPTION
## Summary
- pass spawn position to `BasicEnemyAI`
- use the spawn position when evaluating potential townhall locations
- update `AIManager` and `AIPlayer` to construct the AI with its start position

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6887fd3e14148333b9d6ac5d88e4384d