### PR TITLE
Enable building class creation

### DIFF
--- a/Assets/Script/Actions/TileActionProvider.cs
+++ b/Assets/Script/Actions/TileActionProvider.cs
@@ -74,7 +74,8 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
         void TryBuild(string text, string code)
         {
             player.AddAction(new ControlPanelAction(text, () => {
-                var req = BuildRules.TakeRequirements(code);
+                var building = BuildingFactory.Create(code);
+                var req = building != null ? building.Cost : BuildRules.TakeRequirements(code);
                 if (!ControlPanel.Instance.freeResource)
                 {
                     if (!GameState.playerResources.HasEnough(req))

--- a/Assets/Script/Actions/TileClickHandler.cs
+++ b/Assets/Script/Actions/TileClickHandler.cs
@@ -41,7 +41,11 @@ public class TileClickHandler : MonoBehaviour, IInfoProvider
 
         if (!string.IsNullOrEmpty(cellData.building))
         {
-            player.AddInfo(new InfoItem($"Construcción existente: {cellData.building}", "detail"));
+            Vector2Int pos = new(cellData.x, cellData.y);
+            if (MapState.buildings.TryGetValue(pos, out var b))
+                player.AddInfo(new InfoItem($"Construcción existente: {b.Code} nivel {b.Level}", "detail"));
+            else
+                player.AddInfo(new InfoItem($"Construcción existente: {cellData.building}", "detail"));
         }
     }
 }

--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -253,6 +253,9 @@ public void AssignBuildTask(Vector2Int pos, string building)
             cell.building = building;
             cell.owner = owner;
             GameState.IncrementBuilding(building);
+            var buildingObj = BuildingFactory.Create(building);
+            if (buildingObj != null)
+                MapState.buildings[pos] = buildingObj;
             MapLoader.instance.DrawBuilding(pos, building); // <- 🔥 Dibuja en el tile
             Debug.Log($"{name} construyó {building} en {pos}");
             MapLoader.instance.ClearConstructionPreview(pos);

--- a/Assets/Script/World/Buildings/BuildingFactory.cs
+++ b/Assets/Script/World/Buildings/BuildingFactory.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+public static class BuildingFactory
+{
+    private static readonly Dictionary<string, Func<Building>> constructors = new()
+    {
+        { "townhall", () => new TownhallLevel1() },
+        { "barracks", () => new BarracksLevel1() },
+        { "airport", () => new AirportLevel1() },
+        { "dock", () => new DockLevel1() },
+        { "hut", () => new HutLevel1() },
+        { "farm", () => new FarmLevel1() },
+        { "academy", () => new AcademyLevel1() },
+        { "atalaya", () => new AtalayaLevel1() },
+        { "wall", () => new WallLevel1() },
+        { "lumbermill", () => new SawmillLevel1() },
+        { "extractor", () => new CronoExtractorLevel1() }
+    };
+
+    public static Building Create(string code)
+    {
+        if (string.IsNullOrEmpty(code))
+            return null;
+        return constructors.TryGetValue(code, out var ctor) ? ctor() : null;
+    }
+}

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -198,6 +198,10 @@ public class MapLoader : MonoBehaviour
             ApplyTerrain(tile, cell.terrain);
             ApplyBuilding(tile, cell.building);
 
+            var buildingObj = BuildingFactory.Create(cell.building);
+            if (buildingObj != null)
+                MapState.buildings[coord] = buildingObj;
+
             tiles[coord] = tile;
 
             if (cell.resources != null)
@@ -317,6 +321,10 @@ public class MapLoader : MonoBehaviour
         var renderer = buildingIcon.AddComponent<SpriteRenderer>();
         renderer.sprite = buildingSprites.ContainsKey(building) ? buildingSprites[building] : defaultBuildingSprite;
         renderer.sortingOrder = 10;
+
+        var obj = BuildingFactory.Create(building);
+        if (obj != null)
+            MapState.buildings[pos] = obj;
     }
 
 
@@ -418,6 +426,7 @@ public class MapLoader : MonoBehaviour
         string oldBuilding = cell.building;
         cell.building = null;
         GameState.DecrementBuilding(oldBuilding);
+        MapState.buildings.Remove(pos);
 
         if (tiles.TryGetValue(pos, out var tile))
         {
@@ -443,6 +452,7 @@ public class MapLoader : MonoBehaviour
         cell.building = newBuilding;
         GameState.DecrementBuilding(old);
         GameState.IncrementBuilding(newBuilding);
+        MapState.buildings[pos] = BuildingFactory.Create(newBuilding);
 
         if (tiles.TryGetValue(pos, out var tile))
         {

--- a/Assets/Script/World/MapState.cs
+++ b/Assets/Script/World/MapState.cs
@@ -5,4 +5,5 @@ using UnityEngine;
 public static class MapState
 {
     public static Dictionary<Vector2Int, MapCellDTO> cellMap = new();
+    public static Dictionary<Vector2Int, Building> buildings = new();
 }


### PR DESCRIPTION
## Summary
- store building objects in `MapState`
- add new `BuildingFactory` for building instances
- create building objects when generating the map
- handle buildings in tile info and building actions
- keep building state during build, upgrade or demolish

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68883ff20b3c833386635638f913bbd1