### PR TITLE
Support building sprites per level

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -87,7 +87,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
         currentPath = null;
         taskTarget = GetGridPosition(); // o el pos adyacente exacto
 
-        MapLoader.instance.ShowConstructionPreview(pos, building);
+        MapLoader.instance.ShowConstructionPreview(pos, building, level:1);
         Debug.Log($"{name} ya está al lado de {pos}, construyendo {building}");
         return;
     }
@@ -107,7 +107,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
         currentTask = Task.Build;
         taskTarget = lastReachable;
 
-        MapLoader.instance.ShowConstructionPreview(pos, building);
+        MapLoader.instance.ShowConstructionPreview(pos, building, level:1);
         SetPath(path);
         Debug.Log($"{name} va a construir {building} en {pos} desde {lastReachable}");
     }
@@ -240,7 +240,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
         if (selector != null)
             selector.SetActive(value);
     }
-    void BuildAt(Vector2Int pos, string building)
+    void BuildAt(Vector2Int pos, string building, int level = 1)
     {
 
         if (MapState.cellMap.TryGetValue(pos, out var cell))
@@ -251,12 +251,13 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 return;
             }
             cell.building = building;
+            cell.level = level;
             cell.owner = owner;
             GameState.IncrementBuilding(building);
-            var buildingObj = BuildingFactory.Create(building);
+            var buildingObj = BuildingFactory.Create(building, level);
             if (buildingObj != null)
                 MapState.buildings[pos] = buildingObj;
-            MapLoader.instance.DrawBuilding(pos, building); // <- 🔥 Dibuja en el tile
+            MapLoader.instance.DrawBuilding(pos, building, level); // <- 🔥 Dibuja en el tile
             Debug.Log($"{name} construyó {building} en {pos}");
             MapLoader.instance.ClearConstructionPreview(pos);
 
@@ -291,7 +292,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
 
         if (!moving && currentTask == Task.Build && (currentPath == null || currentPath.Count==0))
         {
-            BuildAt(buildTarget, buildingToConstruct);
+            BuildAt(buildTarget, buildingToConstruct, 1);
             currentTask = Task.None;
             return;
         }
@@ -323,7 +324,7 @@ public void AssignBuildTask(Vector2Int pos, string building)
                     animator.SetWalking(false);
                 if (currentTask == Task.Build && (currentPath == null|| currentPath.Count==0))
                 {
-                    BuildAt(buildTarget, buildingToConstruct);
+                    BuildAt(buildTarget, buildingToConstruct, 1);
                     currentTask = Task.None;
                 }
                 else

--- a/Assets/Script/World/Buildings/BuildingFactory.cs
+++ b/Assets/Script/World/Buildings/BuildingFactory.cs
@@ -3,25 +3,66 @@ using System.Collections.Generic;
 
 public static class BuildingFactory
 {
-    private static readonly Dictionary<string, Func<Building>> constructors = new()
+    private static readonly Dictionary<(string, int), Func<Building>> constructors = new()
     {
-        { "townhall", () => new TownhallLevel1() },
-        { "barracks", () => new BarracksLevel1() },
-        { "airport", () => new AirportLevel1() },
-        { "dock", () => new DockLevel1() },
-        { "hut", () => new HutLevel1() },
-        { "farm", () => new FarmLevel1() },
-        { "academy", () => new AcademyLevel1() },
-        { "atalaya", () => new AtalayaLevel1() },
-        { "wall", () => new WallLevel1() },
-        { "lumbermill", () => new SawmillLevel1() },
-        { "extractor", () => new CronoExtractorLevel1() }
+        { ("townhall", 1), () => new TownhallLevel1() },
+        { ("townhall", 2), () => new TownhallLevel2() },
+        { ("townhall", 3), () => new TownhallLevel3() },
+        { ("townhall", 4), () => new TownhallLevel4() },
+
+        { ("barracks", 1), () => new BarracksLevel1() },
+        { ("barracks", 2), () => new BarracksLevel2() },
+        { ("barracks", 3), () => new BarracksLevel3() },
+        { ("barracks", 4), () => new BarracksLevel4() },
+
+        { ("airport", 1), () => new AirportLevel1() },
+        { ("airport", 2), () => new AirportLevel2() },
+
+        { ("dock", 1), () => new DockLevel1() },
+        { ("dock", 2), () => new DockLevel2() },
+        { ("dock", 3), () => new DockLevel3() },
+        { ("dock", 4), () => new DockLevel4() },
+
+        { ("hut", 1), () => new HutLevel1() },
+        { ("hut", 2), () => new HutLevel2() },
+        { ("hut", 3), () => new HutLevel3() },
+        { ("hut", 4), () => new HutLevel4() },
+
+        { ("farm", 1), () => new FarmLevel1() },
+        { ("farm", 2), () => new FarmLevel2() },
+        { ("farm", 3), () => new FarmLevel3() },
+        { ("farm", 4), () => new FarmLevel4() },
+
+        { ("academy", 1), () => new AcademyLevel1() },
+        { ("academy", 2), () => new AcademyLevel2() },
+        { ("academy", 3), () => new AcademyLevel3() },
+        { ("academy", 4), () => new AcademyLevel4() },
+
+        { ("atalaya", 1), () => new AtalayaLevel1() },
+        { ("atalaya", 2), () => new AtalayaLevel2() },
+        { ("atalaya", 3), () => new AtalayaLevel3() },
+        { ("atalaya", 4), () => new AtalayaLevel4() },
+
+        { ("wall", 1), () => new WallLevel1() },
+        { ("wall", 2), () => new WallLevel2() },
+        { ("wall", 3), () => new WallLevel3() },
+        { ("wall", 4), () => new WallLevel4() },
+
+        { ("lumbermill", 1), () => new SawmillLevel1() },
+        { ("lumbermill", 2), () => new SawmillLevel2() },
+        { ("lumbermill", 3), () => new SawmillLevel3() },
+
+        { ("extractor", 1), () => new CronoExtractorLevel1() },
+        { ("extractor", 2), () => new CronoExtractorLevel2() },
+        { ("extractor", 3), () => new CronoExtractorLevel3() },
+        { ("extractor", 4), () => new CronoExtractorLevel4() },
     };
 
-    public static Building Create(string code)
+    public static Building Create(string code, int level = 1)
     {
         if (string.IsNullOrEmpty(code))
             return null;
-        return constructors.TryGetValue(code, out var ctor) ? ctor() : null;
+
+        return constructors.TryGetValue((code, level), out var ctor) ? ctor() : null;
     }
 }

--- a/Assets/Script/World/DTO.cs
+++ b/Assets/Script/World/DTO.cs
@@ -10,6 +10,7 @@ public class DTO
         public int y;
         public string terrain;
         public string building;
+        public int level = 1;
         public string owner;
         public string start_player;
         public ResourceBundle resources;

--- a/Assets/Script/World/MapGenerator.cs
+++ b/Assets/Script/World/MapGenerator.cs
@@ -73,6 +73,7 @@ public class MapGenerator : MonoBehaviour
                     y = y,
                     terrain = terrain,
                     building = "",//buildings[Random.Range(0, buildings.Length)],
+                    level = 1,
                     owner = "",//owners[Random.Range(0, owners.Length)],
                     start_player = startId,
                     resources = res

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -79,17 +79,59 @@ public class MapLoader : MonoBehaviour
         };
         buildingSprites = new Dictionary<string, Sprite>
         {
-            { "hut", hutSprite },
-            { "dock", dockSprite },
-            { "barracks", barracksSprite },
-            { "mine", mineSprite },
-            { "advanced_mine", mineSprite },
-            { "farm", farmSprite },
-            { "lumbermill", sawmillSprite },
-            { "academy", academySprite },
-            { "extractor", extractorSprite },
-            { "house", hutSprite },
-            { "townhall", defaultBuildingSprite }
+            { "hut_1", hutSprite },
+            { "hut_2", hutSprite },
+            { "hut_3", hutSprite },
+            { "hut_4", hutSprite },
+
+            { "dock_1", dockSprite },
+            { "dock_2", dockSprite },
+            { "dock_3", dockSprite },
+            { "dock_4", dockSprite },
+
+            { "barracks_1", barracksSprite },
+            { "barracks_2", barracksSprite },
+            { "barracks_3", barracksSprite },
+            { "barracks_4", barracksSprite },
+
+            { "mine_1", mineSprite },
+            { "mine_2", mineSprite },
+            { "mine_3", mineSprite },
+            { "mine_4", mineSprite },
+            { "advanced_mine_1", mineSprite },
+            { "advanced_mine_2", mineSprite },
+            { "advanced_mine_3", mineSprite },
+            { "advanced_mine_4", mineSprite },
+
+            { "farm_1", farmSprite },
+            { "farm_2", farmSprite },
+            { "farm_3", farmSprite },
+            { "farm_4", farmSprite },
+
+            { "lumbermill_1", sawmillSprite },
+            { "lumbermill_2", sawmillSprite },
+            { "lumbermill_3", sawmillSprite },
+            { "lumbermill_4", sawmillSprite },
+
+            { "academy_1", academySprite },
+            { "academy_2", academySprite },
+            { "academy_3", academySprite },
+            { "academy_4", academySprite },
+
+            { "extractor_1", extractorSprite },
+            { "extractor_2", extractorSprite },
+            { "extractor_3", extractorSprite },
+            { "extractor_4", extractorSprite },
+
+            { "house_1", hutSprite },
+            { "house_2", hutSprite },
+            { "house_3", hutSprite },
+            { "house_4", hutSprite },
+
+            { "townhall_1", defaultBuildingSprite },
+            { "townhall_2", defaultBuildingSprite },
+            { "townhall_3", defaultBuildingSprite },
+            { "townhall_4", defaultBuildingSprite }
          };
 
 
@@ -118,6 +160,8 @@ public class MapLoader : MonoBehaviour
         MapState.cellMap.Clear();
         foreach (var cell in wrapper.cells)
         {
+            if (cell.level <= 0)
+                cell.level = 1;
             Vector2Int coord = new(cell.x, cell.y);
             MapState.cellMap[coord] = cell;
         }
@@ -127,7 +171,7 @@ public class MapLoader : MonoBehaviour
         PlayerManager.Instance?.InitializePlayers();
         yield return null;
     }
-    public void ShowConstructionPreview(Vector2Int pos, string building)
+    public void ShowConstructionPreview(Vector2Int pos, string building, int level = 1)
     {
         if (!tiles.TryGetValue(pos, out var tile)) return;
 
@@ -138,7 +182,8 @@ public class MapLoader : MonoBehaviour
         preview.transform.localRotation = Quaternion.Euler(-32, 0, 32);
 
         var renderer = preview.AddComponent<SpriteRenderer>();
-        renderer.sprite = buildingSprites.ContainsKey(building) ? buildingSprites[building] : defaultBuildingSprite;
+        string key = $"{building}_{level}";
+        renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.color = new Color(1f, 1f, 1f, 0.4f); // semitransparente
         renderer.sortingOrder = 8;
 
@@ -196,9 +241,9 @@ public class MapLoader : MonoBehaviour
             tile.AddComponent<TileActionProvider>();
 
             ApplyTerrain(tile, cell.terrain);
-            ApplyBuilding(tile, cell.building);
+            ApplyBuilding(tile, cell.building, cell.level);
 
-            var buildingObj = BuildingFactory.Create(cell.building);
+            var buildingObj = BuildingFactory.Create(cell.building, cell.level);
             if (buildingObj != null)
                 MapState.buildings[coord] = buildingObj;
 
@@ -260,7 +305,7 @@ public class MapLoader : MonoBehaviour
             spriteRenderer.sprite = defaultSprite;
        
     }
-    void ApplyBuilding(GameObject tile, string building)
+    void ApplyBuilding(GameObject tile, string building, int level)
     {
         if (string.IsNullOrEmpty(building)) return;
 
@@ -271,7 +316,8 @@ public class MapLoader : MonoBehaviour
         buildingIcon.transform.localRotation = Quaternion.Euler(-90, -30, 40);
         buildingIcon.tag = building;
         var renderer = buildingIcon.AddComponent<SpriteRenderer>();
-        renderer.sprite = buildingSprites.ContainsKey(building) ? buildingSprites[building] : defaultBuildingSprite;
+        string key = $"{building}_{level}";
+        renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.sortingOrder = 10;
 
     }
@@ -308,7 +354,7 @@ public class MapLoader : MonoBehaviour
             );
         }
     }
-    public void DrawBuilding(Vector2Int pos, string building)
+    public void DrawBuilding(Vector2Int pos, string building, int level)
     {
         if (!tiles.TryGetValue(pos, out var tile)) return;
 
@@ -319,10 +365,11 @@ public class MapLoader : MonoBehaviour
         buildingIcon.transform.localRotation = Quaternion.Euler(-32, 0, 32);
 
         var renderer = buildingIcon.AddComponent<SpriteRenderer>();
-        renderer.sprite = buildingSprites.ContainsKey(building) ? buildingSprites[building] : defaultBuildingSprite;
+        string key = $"{building}_{level}";
+        renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.sortingOrder = 10;
 
-        var obj = BuildingFactory.Create(building);
+        var obj = BuildingFactory.Create(building, level);
         if (obj != null)
             MapState.buildings[pos] = obj;
     }
@@ -443,16 +490,17 @@ public class MapLoader : MonoBehaviour
         Debug.Log($"Edificio en {pos} ha sido demolido.");
     }
 
-    public void UpgradeBuilding(Vector2Int pos, string newBuilding)
+    public void UpgradeBuilding(Vector2Int pos, string newBuilding, int level)
     {
         if (!MapState.cellMap.TryGetValue(pos, out var cell))
             return;
 
         string old = cell.building;
         cell.building = newBuilding;
+        cell.level = level;
         GameState.DecrementBuilding(old);
         GameState.IncrementBuilding(newBuilding);
-        MapState.buildings[pos] = BuildingFactory.Create(newBuilding);
+        MapState.buildings[pos] = BuildingFactory.Create(newBuilding, level);
 
         if (tiles.TryGetValue(pos, out var tile))
         {
@@ -466,7 +514,7 @@ public class MapLoader : MonoBehaviour
             }
         }
 
-        DrawBuilding(pos, newBuilding);
+        DrawBuilding(pos, newBuilding, level);
         Debug.Log($"Edificio en {pos} actualizado de {old} a {newBuilding}");
     }
 


### PR DESCRIPTION
## Summary
- extend `MapCellDTO` with a `level` field
- add optional `level` parameter when creating buildings in `BuildingFactory`
- load sprites per building/level and apply them across the map
- store level info when generating maps
- update characters to pass level info when constructing buildings

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6888c683c58c833380cbdf10545d2502