### PR TITLE
Refactor building action handling

### DIFF
--- a/Assets/Script/Actions/BuildingActionHelper.cs
+++ b/Assets/Script/Actions/BuildingActionHelper.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using static DTO;
+
+public static class BuildingActionHelper
+{
+    public static IEnumerable<ControlPanelAction> FromLabels(MapCellDTO cell, params string[] labels)
+    {
+        foreach (var label in labels)
+        {
+            var lower = label.ToLowerInvariant();
+            if (lower.Contains("obrero"))
+                yield return SpawnCharacter(label, cell, Character.Type.Worker);
+            else if (lower.Contains("cientifico"))
+                yield return SpawnCharacter(label, cell, Character.Type.Scientist);
+            else if (lower.Contains("soldado"))
+                yield return SpawnCharacter(label, cell, Character.Type.Warrior);
+            else
+                yield return NotImplemented(label);
+        }
+    }
+    public static ControlPanelAction SpawnCharacter(string label, MapCellDTO cell, Character.Type type)
+    {
+        return new ControlPanelAction(label, () => SpawnCharacterNear(cell, type));
+    }
+
+    public static ControlPanelAction NotImplemented(string label)
+    {
+        return new ControlPanelAction(label, () => Debug.Log($"Acción '{label}' no implementada."));
+    }
+
+    public static void SpawnCharacterNear(MapCellDTO cell, Character.Type type)
+    {
+        var req = BuildRules.TakeRequirements(type);
+        if (!ControlPanel.Instance.freeResource)
+        {
+            if (!GameState.playerResources.HasEnough(req))
+            {
+                Debug.Log($"No hay recursos suficientes para construir {type}");
+                return;
+            }
+        }
+
+        Vector2Int basePos = new(cell.x, cell.y);
+        foreach (var dir in new[] { Vector2Int.up, Vector2Int.down, Vector2Int.left, Vector2Int.right })
+        {
+            Vector2Int target = basePos + dir;
+            if (MapState.cellMap.TryGetValue(target, out var targetCell)
+                && string.IsNullOrEmpty(targetCell.building)
+                && MapLoader.instance.IsPositionFree(target))
+            {
+                ActionManager.Instance.Enqueue(new SpawnCharacterAction(target, type, "player1"));
+                return;
+            }
+        }
+
+        Debug.Log("No hay espacio disponible junto al townhall.");
+    }
+}

--- a/Assets/Script/Actions/TileActionProvider.cs
+++ b/Assets/Script/Actions/TileActionProvider.cs
@@ -30,38 +30,8 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
             Vector2Int posCell = new(cell.x, cell.y);
             if (MapState.buildings.TryGetValue(posCell, out var building))
             {
-                foreach (var act in building.Actions)
-                {
-                    string lower = act.ToLowerInvariant();
-                    if (lower.Contains("obrero"))
-                    {
-                        player.AddAction(new ControlPanelAction(act, () =>
-                        {
-                            SpawnWorkerNear(cell, Character.Type.Worker);
-                        }));
-                    }
-                    else if (lower.Contains("cientifico"))
-                    {
-                        player.AddAction(new ControlPanelAction(act, () =>
-                        {
-                            SpawnWorkerNear(cell, Character.Type.Scientist);
-                        }));
-                    }
-                    else if (lower.Contains("soldado"))
-                    {
-                        player.AddAction(new ControlPanelAction(act, () =>
-                        {
-                            SpawnWorkerNear(cell, Character.Type.Warrior);
-                        }));
-                    }
-                    else
-                    {
-                        player.AddAction(new ControlPanelAction(act, () =>
-                        {
-                            Debug.Log($"Acción '{act}' no implementada.");
-                        }));
-                    }
-                }
+                foreach (var action in building.GetActions(cell))
+                    player.AddAction(action);
             }
 
             if (BuildingEvolutionMatrix.TryGetEvolution(cell.building, cell.level, out var evo))
@@ -169,33 +139,6 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
         return null;
     }
 
-    void SpawnWorkerNear(MapCellDTO cell, Character.Type type)
-    {
-        var req = BuildRules.TakeRequirements(type);
-        if (!ControlPanel.Instance.freeResource)
-        {
-            if (!GameState.playerResources.HasEnough(req))
-            {
-                Debug.Log($"No hay recursos suficientes para construir {type}");
-                return;
-            }
-        }
-
-        Vector2Int basePos = new(cell.x, cell.y);
-        foreach (var dir in new[] { Vector2Int.up, Vector2Int.down, Vector2Int.left, Vector2Int.right })
-        {
-            Vector2Int target = basePos + dir;
-            if (MapState.cellMap.TryGetValue(target, out var targetCell)
-                && string.IsNullOrEmpty(targetCell.building)
-                && MapLoader.instance.IsPositionFree(target))
-            {
-                ActionManager.Instance.Enqueue(new SpawnCharacterAction(target, type, "player1"));
-                return;
-            }
-        }
-
-        Debug.Log("No hay espacio disponible junto al townhall.");
-    }
 
     bool TownhallExists()
     {

--- a/Assets/Script/UI/ControlPanel.cs
+++ b/Assets/Script/UI/ControlPanel.cs
@@ -104,35 +104,6 @@ public class ControlPanel : MonoBehaviour
 
 
     }
-    void SpawnWorkerNear(MapCellDTO cell, Character.Type type )
-    {
-        var req = BuildRules.TakeRequirements(type);
-        if (!freeResource)
-        {
-            if (!GameState.playerResources.HasEnough(req))
-            {
-                Debug.Log($"No hay recursos suficientes para construir {type}");
-                return;
-            }
-        }
-
-
-        Vector2Int basePos = new(cell.x, cell.y);
-        foreach (var dir in new[] {
-        Vector2Int.up, Vector2Int.down, Vector2Int.left, Vector2Int.right })
-        {
-            Vector2Int target = basePos + dir;
-            if (MapState.cellMap.TryGetValue(target, out var targetCell)
-                && string.IsNullOrEmpty(targetCell.building)
-                && MapLoader.instance.IsPositionFree(target))
-            {
-                ActionManager.Instance.Enqueue(new SpawnCharacterAction(target, type, "player1"));
-                return;
-            }
-        }
-
-        Debug.Log("No hay espacio disponible junto al townhall.");
-    }
  
 
     bool TownhallExists()

--- a/Assets/Script/World/Buildings/Building.cs
+++ b/Assets/Script/World/Buildings/Building.cs
@@ -23,5 +23,5 @@ public abstract class Building
     /// <summary>
     /// Acciones habilitadas en este nivel.
     /// </summary>
-    public abstract IReadOnlyList<string> Actions { get; }
+    public abstract IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell);
 }

--- a/Assets/Script/World/Buildings/BuildingDefinitions.cs
+++ b/Assets/Script/World/Buildings/BuildingDefinitions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using static DTO;
 
 /// <summary>
 /// Definiciones de todas las construcciones y sus evoluciones.
@@ -11,28 +12,28 @@ public class TownhallLevel1 : Building
     public override string Code => "townhall";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 0, gold = 0 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo obrero" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero" );
 }
 
 public class TownhallLevel2 : TownhallLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 50, gold = 50 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo obrero", "nuevo marino" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero", "nuevo marino" );
 }
 
 public class TownhallLevel3 : TownhallLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 100, gold = 100 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo obrero", "nuevo marino", "nuevo espia", "nuevo experto" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero", "nuevo marino", "nuevo espia", "nuevo experto" );
 }
 
 public class TownhallLevel4 : TownhallLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 150, gold = 150 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo obrero", "nuevo marino", "nuevo espia", "nuevo experto" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero", "nuevo marino", "nuevo espia", "nuevo experto" );
 }
 #endregion
 
@@ -42,28 +43,28 @@ public class BarracksLevel1 : Building
     public override string Code => "barracks";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 30, gold = 10 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo soldado" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado" );
 }
 
 public class BarracksLevel2 : BarracksLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 60, gold = 30 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo soldado", "nuevo tanque" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo tanque" );
 }
 
 public class BarracksLevel3 : BarracksLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 90, gold = 60 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo soldado", "nuevo tanque", "nuevo elite" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo tanque", "nuevo elite" );
 }
 
 public class BarracksLevel4 : BarracksLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 120, gold = 90 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo soldado", "nuevo tanque", "nuevo elite", "nuevo destructor" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo tanque", "nuevo elite", "nuevo destructor" );
 }
 #endregion
 
@@ -73,14 +74,14 @@ public class AirportLevel1 : Building
     public override string Code => "airport";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40, gold = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo avion" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo avion" );
 }
 
 public class AirportLevel2 : AirportLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 80, gold = 40 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo avion", "nuevo bombardero" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo avion", "nuevo bombardero" );
 }
 #endregion
 
@@ -90,28 +91,28 @@ public class DockLevel1 : Building
     public override string Code => "dock";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 25, gold = 10 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo pesquero" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo pesquero" );
 }
 
 public class DockLevel2 : DockLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 50, gold = 30 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo pesquero", "nuevo mercante" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo pesquero", "nuevo mercante" );
 }
 
 public class DockLevel3 : DockLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 75, gold = 60 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo pesquero", "nuevo mercante", "nuevo patrulla" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo pesquero", "nuevo mercante", "nuevo patrulla" );
 }
 
 public class DockLevel4 : DockLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 100, gold = 100 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo pesquero", "nuevo mercante", "nuevo patrulla", "nuevo portavion" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo pesquero", "nuevo mercante", "nuevo patrulla", "nuevo portavion" );
 }
 #endregion
 
@@ -121,28 +122,28 @@ public class HutLevel1 : Building
     public override string Code => "hut";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 10 };
-    public override IReadOnlyList<string> Actions => new[] { "otorga 4 lugares" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "otorga 4 lugares" );
 }
 
 public class HutLevel2 : HutLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "otorga 8 lugares" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "otorga 8 lugares" );
 }
 
 public class HutLevel3 : HutLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 30 };
-    public override IReadOnlyList<string> Actions => new[] { "otorga 16 lugares" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "otorga 16 lugares" );
 }
 
 public class HutLevel4 : HutLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40 };
-    public override IReadOnlyList<string> Actions => new[] { "otorga 32 lugares" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "otorga 32 lugares" );
 }
 #endregion
 
@@ -152,28 +153,28 @@ public class FarmLevel1 : Building
     public override string Code => "farm";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "genera 4 de comida" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "genera 4 de comida" );
 }
 
 public class FarmLevel2 : FarmLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40 };
-    public override IReadOnlyList<string> Actions => new[] { "genera 8 de comida" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "genera 8 de comida" );
 }
 
 public class FarmLevel3 : FarmLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 60 };
-    public override IReadOnlyList<string> Actions => new[] { "genera 16 de comida" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "genera 16 de comida" );
 }
 
 public class FarmLevel4 : FarmLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 80 };
-    public override IReadOnlyList<string> Actions => new[] { "genera 32 de comida" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "genera 32 de comida" );
 }
 #endregion
 
@@ -183,28 +184,28 @@ public class AcademyLevel1 : Building
     public override string Code => "academy";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 30, gold = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo aprendiz" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo aprendiz" );
 }
 
 public class AcademyLevel2 : AcademyLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 60, gold = 40 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo aprendiz", "nuevo medico" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo aprendiz", "nuevo medico" );
 }
 
 public class AcademyLevel3 : AcademyLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 90, gold = 60 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo aprendiz", "nuevo medico", "nuevo erudito" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo aprendiz", "nuevo medico", "nuevo erudito" );
 }
 
 public class AcademyLevel4 : AcademyLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 120, gold = 80 };
-    public override IReadOnlyList<string> Actions => new[] { "nuevo aprendiz", "nuevo medico", "nuevo erudito", "nuevo cientifico" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo aprendiz", "nuevo medico", "nuevo erudito", "nuevo cientifico" );
 }
 #endregion
 
@@ -214,28 +215,28 @@ public class AtalayaLevel1 : Building
     public override string Code => "atalaya";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "Defensa 4 disparos por segundo" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 4 disparos por segundo" );
 }
 
 public class AtalayaLevel2 : AtalayaLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40 };
-    public override IReadOnlyList<string> Actions => new[] { "Defensa 8 disparos por segundo" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 8 disparos por segundo" );
 }
 
 public class AtalayaLevel3 : AtalayaLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 60 };
-    public override IReadOnlyList<string> Actions => new[] { "Defensa 16 disparos por segundo" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 16 disparos por segundo" );
 }
 
 public class AtalayaLevel4 : AtalayaLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 80 };
-    public override IReadOnlyList<string> Actions => new[] { "Defensa 32 disparos por segundo" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 32 disparos por segundo" );
 }
 #endregion
 
@@ -245,28 +246,28 @@ public class WallLevel1 : Building
     public override string Code => "wall";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 10 };
-    public override IReadOnlyList<string> Actions => new[] { "resistencia 10" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "resistencia 10" );
 }
 
 public class WallLevel2 : WallLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "resistencia 20" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "resistencia 20" );
 }
 
 public class WallLevel3 : WallLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 30 };
-    public override IReadOnlyList<string> Actions => new[] { "resistencia 30" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "resistencia 30" );
 }
 
 public class WallLevel4 : WallLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40 };
-    public override IReadOnlyList<string> Actions => new[] { "resistencia 40" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "resistencia 40" );
 }
 #endregion
 
@@ -276,21 +277,21 @@ public class SawmillLevel1 : Building
     public override string Code => "lumbermill";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 15, gold = 5 };
-    public override IReadOnlyList<string> Actions => new[] { "potencia madera por 5" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "potencia madera por 5" );
 }
 
 public class SawmillLevel2 : SawmillLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 30, gold = 10 };
-    public override IReadOnlyList<string> Actions => new[] { "potencia madera por 15" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "potencia madera por 15" );
 }
 
 public class SawmillLevel3 : SawmillLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 45, gold = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "potencia madera por 30" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "potencia madera por 30" );
 }
 #endregion
 
@@ -300,28 +301,28 @@ public class CronoExtractorLevel1 : Building
     public override string Code => "extractor";
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { gold = 20, wood = 20, sciencePoints = 10 };
-    public override IReadOnlyList<string> Actions => new[] { "Nuevo hechicero", "Asistencia futuro" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Nuevo hechicero", "Asistencia futuro" );
 }
 
 public class CronoExtractorLevel2 : CronoExtractorLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { gold = 40, wood = 40, sciencePoints = 20 };
-    public override IReadOnlyList<string> Actions => new[] { "Nuevo hechicero", "Asistencia futuro", "Misiones pasado" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Nuevo hechicero", "Asistencia futuro", "Misiones pasado" );
 }
 
 public class CronoExtractorLevel3 : CronoExtractorLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { gold = 60, wood = 60, sciencePoints = 30 };
-    public override IReadOnlyList<string> Actions => new[] { "Nuevo hechicero", "Asistencia futuro", "Misiones pasado", "proteccion" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Nuevo hechicero", "Asistencia futuro", "Misiones pasado", "proteccion" );
 }
 
 public class CronoExtractorLevel4 : CronoExtractorLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { gold = 80, wood = 80, sciencePoints = 40 };
-    public override IReadOnlyList<string> Actions => new[] { "Nuevo hechicero", "Asistencia futuro", "Misiones pasado", "proteccion", "envio tabla" };
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Nuevo hechicero", "Asistencia futuro", "Misiones pasado", "proteccion", "envio tabla" );
 }
 #endregion
 


### PR DESCRIPTION
## Summary
- switch `Building` to expose actions via `GetActions(MapCellDTO)`
- add `BuildingActionHelper` utility for mapping labels to callbacks
- update building definitions to use the helper
- simplify `TileActionProvider` and `ControlPanel` to consume new API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68890c72493c8333aecabe4d4763d8c5