### PR TITLE
Add wood transfer on building construction

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -254,6 +254,12 @@ public void AssignBuildTask(Vector2Int pos, string building)
             cell.building = building;
             cell.level = level;
             cell.owner = owner;
+
+            if (cell.resources != null && cell.resources.wood > 0)
+            {
+                GameState.playerResources.wood += cell.resources.wood;
+                cell.resources.wood = 0;
+            }
             GameState.IncrementBuilding(building);
             var buildingObj = BuildingFactory.Create(building, level);
             if (buildingObj != null)


### PR DESCRIPTION
## Summary
- add wood from tile to player's resources when constructing a building

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_68892da8f3a483339aa8eefbeaebcd36