### PR TITLE
Add fog of war overlay

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -327,6 +327,8 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 transform.position = targetPosition;
                 moving = false;
 
+                MapLoader.instance?.RevealRadius(GetGridPosition(), 1);
+
                 if (animator != null)
                     animator.SetWalking(false);
                 if (currentTask == Task.Build && (currentPath == null|| currentPath.Count==0))

--- a/Assets/Script/Players/Player.cs
+++ b/Assets/Script/Players/Player.cs
@@ -14,7 +14,10 @@ public abstract class Player
     public virtual void Initialize()
     {
         if (MapLoader.instance != null)
+        {
             MapLoader.instance.SpawnCharacter(SpawnPosition, Character.Type.Worker, Id);
+            MapLoader.instance.RevealRadius(SpawnPosition, 1);
+        }
     }
 
     public virtual void Update() { }

--- a/Assets/Script/World/FogTile.cs
+++ b/Assets/Script/World/FogTile.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public class FogTile : MonoBehaviour
+{
+    public Vector2Int position;
+    private SpriteRenderer overlay;
+
+    public void Initialize(Vector2Int coord, SpriteRenderer renderer)
+    {
+        position = coord;
+        overlay = renderer;
+        UpdateVisibility();
+    }
+
+    public void Reveal()
+    {
+        if (overlay != null)
+            overlay.enabled = false;
+        MapState.exploredCells.Add(position);
+    }
+
+    public void UpdateVisibility()
+    {
+        if (overlay != null)
+            overlay.enabled = !MapState.exploredCells.Contains(position);
+    }
+}

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -295,6 +295,8 @@ public class MapLoader : MonoBehaviour
             ApplyTerrain(tile, cell.terrain);
             ApplyBuilding(tile, cell.building, cell.level);
 
+            AddFog(tile, coord);
+
             var buildingObj = BuildingFactory.Create(cell.building, cell.level);
             if (buildingObj != null)
                 MapState.buildings[coord] = buildingObj;
@@ -441,6 +443,45 @@ public class MapLoader : MonoBehaviour
         iconObj.AddComponent<Billboard>();
 
 
+    }
+
+    void AddFog(GameObject tile, Vector2Int coord)
+    {
+        var baseRenderer = tile.GetComponentInChildren<SpriteRenderer>();
+        if (baseRenderer == null) return;
+
+        GameObject fogObj = new GameObject("Fog");
+        fogObj.transform.SetParent(tile.transform);
+        fogObj.transform.localPosition = baseRenderer.transform.localPosition;
+        fogObj.transform.localRotation = baseRenderer.transform.localRotation;
+        fogObj.transform.localScale = baseRenderer.transform.localScale;
+
+        var fogRenderer = fogObj.AddComponent<SpriteRenderer>();
+        fogRenderer.sprite = baseRenderer.sprite;
+        fogRenderer.color = new Color(0, 0, 0, 0.75f);
+        fogRenderer.sortingOrder = 30;
+
+        var fog = tile.AddComponent<FogTile>();
+        fog.Initialize(coord, fogRenderer);
+    }
+
+    public void RevealTile(Vector2Int pos)
+    {
+        if (!tiles.TryGetValue(pos, out var tile)) return;
+        var fog = tile.GetComponent<FogTile>();
+        if (fog != null) fog.Reveal();
+    }
+
+    public void RevealRadius(Vector2Int center, int radius)
+    {
+        for (int dx = -radius; dx <= radius; dx++)
+        {
+            for (int dy = -radius; dy <= radius; dy++)
+            {
+                Vector2Int p = new Vector2Int(center.x + dx, center.y + dy);
+                RevealTile(p);
+            }
+        }
     }
 
 

--- a/Assets/Script/World/MapState.cs
+++ b/Assets/Script/World/MapState.cs
@@ -6,4 +6,5 @@ public static class MapState
 {
     public static Dictionary<Vector2Int, MapCellDTO> cellMap = new();
     public static Dictionary<Vector2Int, Building> buildings = new();
+    public static HashSet<Vector2Int> exploredCells = new();
 }


### PR DESCRIPTION
## Summary
- keep track of explored cells in `MapState`
- overlay tiles with a fog layer via new `FogTile` component
- reveal areas when characters move or upon player spawn

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_68893e9ee770833396997c441069b6b6