### PR TITLE
Limit fog reveal to human player

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -327,7 +327,11 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 transform.position = targetPosition;
                 moving = false;
 
-                MapLoader.instance?.RevealRadius(GetGridPosition(), 1);
+                if (PlayerManager.Instance == null ||
+                    PlayerManager.Instance.IsHumanPlayer(owner))
+                {
+                    MapLoader.instance?.RevealRadius(GetGridPosition(), 1);
+                }
 
                 if (animator != null)
                     animator.SetWalking(false);

--- a/Assets/Script/Players/AIPlayer.cs
+++ b/Assets/Script/Players/AIPlayer.cs
@@ -11,7 +11,10 @@ public class AIPlayer : Player
 
     public override void Initialize()
     {
-        base.Initialize();
+        if (MapLoader.instance != null)
+        {
+            MapLoader.instance.SpawnCharacter(SpawnPosition, Character.Type.Worker, Id);
+        }
     }
 
     public override void Update()

--- a/Assets/Script/Players/PlayerManager.cs
+++ b/Assets/Script/Players/PlayerManager.cs
@@ -10,6 +10,16 @@ public class PlayerManager : MonoBehaviour
     private readonly List<Player> players = new();
     public Vector2Int Player1Spawn { get; private set; }
 
+    public bool IsHumanPlayer(string id)
+    {
+        foreach (var p in players)
+        {
+            if (p.Id == id)
+                return p is HumanPlayer;
+        }
+        return false;
+    }
+
     readonly Vector2Int[] defaultSpawns = new Vector2Int[]
     {
         new Vector2Int(1,1),


### PR DESCRIPTION
## Summary
- add `IsHumanPlayer` helper to `PlayerManager`
- make AI characters stop revealing fog when moving
- don't reveal fog for AI players at spawn

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_68895e22b1488333ae58332adac44f72