### PR TITLE
Improve fog overlay

### DIFF
--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -463,7 +463,8 @@ public class MapLoader : MonoBehaviour
         var fogRenderer = fogObj.AddComponent<SpriteRenderer>();
         fogRenderer.sprite = baseRenderer.sprite;
         fogRenderer.color = new Color(0, 0, 0, 1f);
-        fogRenderer.sortingOrder = baseRenderer.sortingOrder + 5;
+        // Ensure fog covers buildings and other objects on the tile
+        fogRenderer.sortingOrder = 11;
         fogRenderer.sortingLayerID = baseRenderer.sortingLayerID;
 
         var fog = tile.AddComponent<FogTile>();


### PR DESCRIPTION
## Summary
- adjust fog sprite sorting order so rival buildings are hidden when fog is active

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68896158e37883339c8d60dcda5046c4