### PR TITLE
Implement building visibility radius

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -265,6 +265,8 @@ public void AssignBuildTask(Vector2Int pos, string building)
             if (buildingObj != null)
                 MapState.buildings[pos] = buildingObj;
             MapLoader.instance.DrawBuilding(pos, building, level); // <- 🔥 Dibuja en el tile
+            if (buildingObj != null)
+                MapLoader.instance.RevealRadius(pos, buildingObj.VisibilityRadius);
             Debug.Log($"{name} construyó {building} en {pos}");
             MapLoader.instance.ClearConstructionPreview(pos);
 

--- a/Assets/Script/World/Buildings/Building.cs
+++ b/Assets/Script/World/Buildings/Building.cs
@@ -22,6 +22,11 @@ public abstract class Building
     public abstract BuildRequirement Cost { get; }
 
     /// <summary>
+    /// Radio de visibilidad que despeja la construcción.
+    /// </summary>
+    public virtual int VisibilityRadius => 2;
+
+    /// <summary>
     /// Acciones habilitadas en este nivel.
     /// </summary>
     public abstract IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell);

--- a/Assets/Script/World/Buildings/BuildingDefinitions.cs
+++ b/Assets/Script/World/Buildings/BuildingDefinitions.cs
@@ -13,6 +13,7 @@ public class TownhallLevel1 : Building
     public override string Code => BuildingCodes.Townhall;
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 0, gold = 0 };
+    public override int VisibilityRadius => 5;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero" );
 }
 
@@ -20,6 +21,7 @@ public class TownhallLevel2 : TownhallLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 50, gold = 50 };
+    public override int VisibilityRadius => 5;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero", "nuevo marino" );
 }
 
@@ -27,6 +29,7 @@ public class TownhallLevel3 : TownhallLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 100, gold = 100 };
+    public override int VisibilityRadius => 5;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero", "nuevo marino", "nuevo espia", "nuevo experto" );
 }
 
@@ -34,6 +37,7 @@ public class TownhallLevel4 : TownhallLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 150, gold = 150 };
+    public override int VisibilityRadius => 5;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo obrero", "nuevo marino", "nuevo espia", "nuevo experto" );
 }
 #endregion
@@ -75,6 +79,7 @@ public class AirportLevel1 : Building
     public override string Code => BuildingCodes.Airport;
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40, gold = 20 };
+    public override int VisibilityRadius => 6;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo avion" );
 }
 
@@ -82,6 +87,7 @@ public class AirportLevel2 : AirportLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 80, gold = 40 };
+    public override int VisibilityRadius => 6;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo avion", "nuevo bombardero" );
 }
 #endregion
@@ -216,6 +222,7 @@ public class AtalayaLevel1 : Building
     public override string Code => BuildingCodes.Atalaya;
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 20 };
+    public override int VisibilityRadius => 3 + Level;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 4 disparos por segundo" );
 }
 
@@ -223,6 +230,7 @@ public class AtalayaLevel2 : AtalayaLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40 };
+    public override int VisibilityRadius => 3 + Level;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 8 disparos por segundo" );
 }
 
@@ -230,6 +238,7 @@ public class AtalayaLevel3 : AtalayaLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 60 };
+    public override int VisibilityRadius => 3 + Level;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 16 disparos por segundo" );
 }
 
@@ -237,6 +246,7 @@ public class AtalayaLevel4 : AtalayaLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 80 };
+    public override int VisibilityRadius => 3 + Level;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 32 disparos por segundo" );
 }
 #endregion

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -616,6 +616,8 @@ public class MapLoader : MonoBehaviour
         }
 
         DrawBuilding(pos, newBuilding, level);
+        if (MapState.buildings.TryGetValue(pos, out var b))
+            RevealRadius(pos, b.VisibilityRadius);
         Debug.Log($"Edificio en {pos} actualizado de {old} a {newBuilding}");
     }
 


### PR DESCRIPTION
## Summary
- add `VisibilityRadius` property to `Building`
- define custom visibility for Townhall, Atalaya and Airport
- reveal fog around new buildings and upgrades

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68896dac1ea48333838741d646290cba