### PR TITLE
Restrict fog reveal to human player buildings

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -265,7 +265,8 @@ public void AssignBuildTask(Vector2Int pos, string building)
             if (buildingObj != null)
                 MapState.buildings[pos] = buildingObj;
             MapLoader.instance.DrawBuilding(pos, building, level); // <- 🔥 Dibuja en el tile
-            if (buildingObj != null)
+            if (buildingObj != null &&
+                (PlayerManager.Instance == null || PlayerManager.Instance.IsHumanPlayer(owner)))
                 MapLoader.instance.RevealRadius(pos, buildingObj.VisibilityRadius);
             Debug.Log($"{name} construyó {building} en {pos}");
             MapLoader.instance.ClearConstructionPreview(pos);

--- a/Assets/Script/Players/PlayerManager.cs
+++ b/Assets/Script/Players/PlayerManager.cs
@@ -67,6 +67,15 @@ public class PlayerManager : MonoBehaviour
         foreach (var p in players)
             p.Initialize();
 
+        foreach (var kv in MapState.cellMap)
+        {
+            if (!string.IsNullOrEmpty(kv.Value.building) && IsHumanPlayer(kv.Value.owner))
+            {
+                if (MapState.buildings.TryGetValue(kv.Key, out var b))
+                    MapLoader.instance?.RevealRadius(kv.Key, b.VisibilityRadius);
+            }
+        }
+
         FindObjectOfType<CameraController>().FocusOnCell(Player1Spawn);
     }
 

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -616,7 +616,8 @@ public class MapLoader : MonoBehaviour
         }
 
         DrawBuilding(pos, newBuilding, level);
-        if (MapState.buildings.TryGetValue(pos, out var b))
+        if (MapState.buildings.TryGetValue(pos, out var b) &&
+            (PlayerManager.Instance == null || PlayerManager.Instance.IsHumanPlayer(cell.owner)))
             RevealRadius(pos, b.VisibilityRadius);
         Debug.Log($"Edificio en {pos} actualizado de {old} a {newBuilding}");
     }


### PR DESCRIPTION
## Summary
- only reveal fog from buildings if they belong to the human player
- reveal visibility for existing human buildings when players are initialized

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_688979e880988333a9b6508a66463262