### PR TITLE
Add orientation handling for bridge and wall segments

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 using static DTO;
 using GameConstants;
 
+// Orientation is used for directional buildings like bridges or walls
+
 public class Character : MonoBehaviour, IActionProposer, IInfoProvider
 {
     public enum Type { Worker, Scientist, Warrior }
@@ -88,7 +90,8 @@ public void AssignBuildTask(Vector2Int pos, string building)
         currentPath = null;
         taskTarget = GetGridPosition(); // o el pos adyacente exacto
 
-        MapLoader.instance.ShowConstructionPreview(pos, building, level:1);
+        Orientation orient = DetermineOrientation(pos, building);
+        MapLoader.instance.ShowConstructionPreview(pos, building, level:1, orientation:orient);
         Debug.Log($"{name} ya está al lado de {pos}, construyendo {building}");
         return;
     }
@@ -108,7 +111,8 @@ public void AssignBuildTask(Vector2Int pos, string building)
         currentTask = Task.Build;
         taskTarget = lastReachable;
 
-        MapLoader.instance.ShowConstructionPreview(pos, building, level:1);
+        Orientation orient = DetermineOrientation(pos, building);
+        MapLoader.instance.ShowConstructionPreview(pos, building, level:1, orientation:orient);
         SetPath(path);
         Debug.Log($"{name} va a construir {building} en {pos} desde {lastReachable}");
     }
@@ -241,6 +245,44 @@ public void AssignBuildTask(Vector2Int pos, string building)
         if (selector != null)
             selector.SetActive(value);
     }
+
+    Orientation DetermineOrientation(Vector2Int pos, string building)
+    {
+        bool horiz = false;
+        bool vert = false;
+        Vector2Int[] horizDirs = { Vector2Int.left, Vector2Int.right };
+        foreach (var d in horizDirs)
+        {
+            Vector2Int n = pos + d;
+            if (MapState.cellMap.TryGetValue(n, out var cell) && cell.building == building)
+                horiz = true;
+        }
+        Vector2Int[] vertDirs = { Vector2Int.up, Vector2Int.down };
+        foreach (var d in vertDirs)
+        {
+            Vector2Int n = pos + d;
+            if (MapState.cellMap.TryGetValue(n, out var cell) && cell.building == building)
+                vert = true;
+        }
+        if (vert && !horiz) return Orientation.Vertical;
+        return Orientation.Horizontal;
+    }
+
+    void AdjustNeighbours(Vector2Int pos, string building, Orientation orientation)
+    {
+        Vector2Int[] dirs = orientation == Orientation.Horizontal ?
+            new[] { Vector2Int.left, Vector2Int.right } :
+            new[] { Vector2Int.up, Vector2Int.down };
+        foreach (var d in dirs)
+        {
+            Vector2Int n = pos + d;
+            if (MapState.buildings.TryGetValue(n, out var b) && b.Code == building)
+            {
+                b.Orientation = orientation;
+                MapLoader.instance.UpdateBuildingOrientation(n, orientation);
+            }
+        }
+    }
     void BuildAt(Vector2Int pos, string building, int level = 1)
     {
 
@@ -261,10 +303,15 @@ public void AssignBuildTask(Vector2Int pos, string building)
                 cell.resources.wood = 0;
             }
             GameState.IncrementBuilding(building);
+            Orientation orient = DetermineOrientation(pos, building);
             var buildingObj = BuildingFactory.Create(building, level);
             if (buildingObj != null)
+            {
+                buildingObj.Orientation = orient;
                 MapState.buildings[pos] = buildingObj;
-            MapLoader.instance.DrawBuilding(pos, building, level); // <- 🔥 Dibuja en el tile
+            }
+            MapLoader.instance.DrawBuilding(pos, building, level, orient); // <- 🔥 Dibuja en el tile
+            AdjustNeighbours(pos, building, orient);
             if (buildingObj != null &&
                 (PlayerManager.Instance == null || PlayerManager.Instance.IsHumanPlayer(owner)))
                 MapLoader.instance.RevealRadius(pos, buildingObj.VisibilityRadius);

--- a/Assets/Script/World/Buildings/Building.cs
+++ b/Assets/Script/World/Buildings/Building.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using static DTO;
 
+// Defines horizontal or vertical placement for buildings that span multiple tiles
+
 /// <summary>
 /// Clase base para todas las construcciones del juego.
 /// </summary>
@@ -25,6 +27,8 @@ public abstract class Building
     /// Radio de visibilidad que despeja la construcción.
     /// </summary>
     public virtual int VisibilityRadius => 2;
+
+    public Orientation Orientation { get; set; } = Orientation.Horizontal;
 
     /// <summary>
     /// Acciones habilitadas en este nivel.

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -6,6 +6,8 @@ using UnityEngine.Networking;
 using static MapGenerator;
 using GameConstants;
 using static DTO;
+
+// Orientation enum used for bridges/walls
 using Unity.VisualScripting.Antlr3.Runtime.Tree;
 
 
@@ -231,7 +233,7 @@ public class MapLoader : MonoBehaviour
         PlayerManager.Instance?.InitializePlayers();
         yield return null;
     }
-    public void ShowConstructionPreview(Vector2Int pos, string building, int level = 1)
+    public void ShowConstructionPreview(Vector2Int pos, string building, int level = 1, Orientation orientation = Orientation.Horizontal)
     {
         if (!tiles.TryGetValue(pos, out var tile)) return;
 
@@ -239,7 +241,8 @@ public class MapLoader : MonoBehaviour
         preview.transform.SetParent(tile.transform);
         preview.transform.localPosition = new Vector3(-0.5f, .7f, -0.25f);
         preview.transform.localScale = Vector3.one * 0.35f;
-        preview.transform.localRotation = Quaternion.Euler(-32, 0, 32);
+        float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
+        preview.transform.localRotation = Quaternion.Euler(-32, yRot, 32);
 
         var renderer = preview.AddComponent<SpriteRenderer>();
         string key = $"{building}_{level}";
@@ -367,7 +370,7 @@ public class MapLoader : MonoBehaviour
             spriteRenderer.sprite = defaultSprite;
        
     }
-    void ApplyBuilding(GameObject tile, string building, int level)
+    void ApplyBuilding(GameObject tile, string building, int level, Orientation orientation = Orientation.Horizontal)
     {
         if (string.IsNullOrEmpty(building)) return;
 
@@ -375,7 +378,8 @@ public class MapLoader : MonoBehaviour
         buildingIcon.transform.SetParent(tile.transform);
         buildingIcon.transform.localPosition = new Vector3(0, 1f, -0.25f);
         buildingIcon.transform.localScale = Vector3.one * 0.45f;
-        buildingIcon.transform.localRotation = Quaternion.Euler(-90, -30, 40);
+        float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
+        buildingIcon.transform.localRotation = Quaternion.Euler(-90, yRot - 30f, 40);
         buildingIcon.tag = building;
         var renderer = buildingIcon.AddComponent<SpriteRenderer>();
         string key = $"{building}_{level}";
@@ -416,7 +420,7 @@ public class MapLoader : MonoBehaviour
             );
         }
     }
-    public void DrawBuilding(Vector2Int pos, string building, int level)
+    public void DrawBuilding(Vector2Int pos, string building, int level, Orientation orientation = Orientation.Horizontal)
     {
         if (!tiles.TryGetValue(pos, out var tile)) return;
 
@@ -424,7 +428,8 @@ public class MapLoader : MonoBehaviour
         buildingIcon.transform.SetParent(tile.transform);
         buildingIcon.transform.localPosition = new Vector3(-0.5f, .7f, -0.25f);
         buildingIcon.transform.localScale = Vector3.one * 0.35f;
-        buildingIcon.transform.localRotation = Quaternion.Euler(-32, 0, 32);
+        float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
+        buildingIcon.transform.localRotation = Quaternion.Euler(-32, yRot, 32);
 
         var renderer = buildingIcon.AddComponent<SpriteRenderer>();
         string key = $"{building}_{level}";
@@ -434,6 +439,20 @@ public class MapLoader : MonoBehaviour
         var obj = BuildingFactory.Create(building, level);
         if (obj != null)
             MapState.buildings[pos] = obj;
+    }
+
+    public void UpdateBuildingOrientation(Vector2Int pos, Orientation orientation)
+    {
+        if (!tiles.TryGetValue(pos, out var tile)) return;
+        foreach (Transform child in tile.transform)
+        {
+            if (child.name.StartsWith("Building_"))
+            {
+                float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
+                child.localRotation = Quaternion.Euler(-32, yRot, 32);
+                break;
+            }
+        }
     }
 
 
@@ -609,7 +628,12 @@ public class MapLoader : MonoBehaviour
         cell.level = level;
         GameState.DecrementBuilding(old);
         GameState.IncrementBuilding(newBuilding);
+        Orientation orient = Orientation.Horizontal;
+        if (MapState.buildings.TryGetValue(pos, out var existing))
+            orient = existing.Orientation;
         MapState.buildings[pos] = BuildingFactory.Create(newBuilding, level);
+        if (MapState.buildings[pos] != null)
+            MapState.buildings[pos].Orientation = orient;
 
         if (tiles.TryGetValue(pos, out var tile))
         {
@@ -623,7 +647,7 @@ public class MapLoader : MonoBehaviour
             }
         }
 
-        DrawBuilding(pos, newBuilding, level);
+        DrawBuilding(pos, newBuilding, level, orient);
         if (MapState.buildings.TryGetValue(pos, out var b) &&
             (PlayerManager.Instance == null || PlayerManager.Instance.IsHumanPlayer(cell.owner)))
             RevealRadius(pos, b.VisibilityRadius);

--- a/Assets/Script/World/Orientation.cs
+++ b/Assets/Script/World/Orientation.cs
@@ -1,0 +1,5 @@
+public enum Orientation
+{
+    Horizontal,
+    Vertical
+}


### PR DESCRIPTION
## Summary
- add `Orientation` enum to support horizontal/vertical buildings
- store orientation in `Building`
- update `MapLoader` to preview, draw and upgrade buildings with orientation
- adjust `Character` build logic to determine orientation based on neighbours and align adjacent pieces

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a0ff7d4888333a2a2bd5306f777b9