### PR TITLE
Refactor building API to pass objects

### DIFF
--- a/Assets/Script/Actions/TileActionProvider.cs
+++ b/Assets/Script/Actions/TileActionProvider.cs
@@ -49,7 +49,8 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
                         }
                         GameState.playerResources.Consume(req);
                         GameState.playerResources.science -= evo.requiredScience;
-                        MapLoader.instance.UpgradeBuilding(new Vector2Int(cell.x, cell.y), evo.next, evo.level);
+                        var newBuilding = BuildingFactory.Create(evo.next, evo.level);
+                        MapLoader.instance.UpgradeBuilding(new Vector2Int(cell.x, cell.y), newBuilding);
                         GameEvents.RaiseSelection(gameObject);
                     }));
                 }

--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -91,7 +91,12 @@ public void AssignBuildTask(Vector2Int pos, string building)
         taskTarget = GetGridPosition(); // o el pos adyacente exacto
 
         Orientation orient = DetermineOrientation(pos, building);
-        MapLoader.instance.ShowConstructionPreview(pos, building, level:1, orientation:orient);
+        var previewBuilding = BuildingFactory.Create(building);
+        if (previewBuilding != null)
+        {
+            previewBuilding.Orientation = orient;
+            MapLoader.instance.ShowConstructionPreview(pos, previewBuilding);
+        }
         Debug.Log($"{name} ya está al lado de {pos}, construyendo {building}");
         return;
     }
@@ -112,7 +117,12 @@ public void AssignBuildTask(Vector2Int pos, string building)
         taskTarget = lastReachable;
 
         Orientation orient = DetermineOrientation(pos, building);
-        MapLoader.instance.ShowConstructionPreview(pos, building, level:1, orientation:orient);
+        var previewBuilding2 = BuildingFactory.Create(building);
+        if (previewBuilding2 != null)
+        {
+            previewBuilding2.Orientation = orient;
+            MapLoader.instance.ShowConstructionPreview(pos, previewBuilding2);
+        }
         SetPath(path);
         Debug.Log($"{name} va a construir {building} en {pos} desde {lastReachable}");
     }
@@ -309,8 +319,8 @@ public void AssignBuildTask(Vector2Int pos, string building)
             {
                 buildingObj.Orientation = orient;
                 MapState.buildings[pos] = buildingObj;
+                MapLoader.instance.DrawBuilding(pos, buildingObj); // <- 🔥 Dibuja en el tile
             }
-            MapLoader.instance.DrawBuilding(pos, building, level, orient); // <- 🔥 Dibuja en el tile
             AdjustNeighbours(pos, building, orient);
             if (buildingObj != null &&
                 (PlayerManager.Instance == null || PlayerManager.Instance.IsHumanPlayer(owner)))

--- a/Assets/Script/World/Buildings/Building.cs
+++ b/Assets/Script/World/Buildings/Building.cs
@@ -31,6 +31,17 @@ public abstract class Building
     public Orientation Orientation { get; set; } = Orientation.Horizontal;
 
     /// <summary>
+    /// Indicates if the sprite should rotate when the orientation changes.
+    /// Bridges don't rotate so they override this.
+    /// </summary>
+    public virtual bool ShouldRotate => true;
+
+    /// <summary>
+    /// Key used to pick the sprite for this building.
+    /// </summary>
+    public virtual string SpriteKey => $"{Code}_{Level}";
+
+    /// <summary>
     /// Acciones habilitadas en este nivel.
     /// </summary>
     public abstract IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell);

--- a/Assets/Script/World/Buildings/BuildingDefinitions.cs
+++ b/Assets/Script/World/Buildings/BuildingDefinitions.cs
@@ -380,6 +380,8 @@ public class BridgeLevel1 : Building
     public override string Code => BuildingCodes.Bridge;
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 10 };
+    public override bool ShouldRotate => false;
+    public override string SpriteKey => $"{Code}_{(Orientation == Orientation.Horizontal ? "H" : "V")}";
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell);
 }
 

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -233,22 +233,20 @@ public class MapLoader : MonoBehaviour
         PlayerManager.Instance?.InitializePlayers();
         yield return null;
     }
-    public void ShowConstructionPreview(Vector2Int pos, string building, int level = 1, Orientation orientation = Orientation.Horizontal)
+    public void ShowConstructionPreview(Vector2Int pos, Building building)
     {
+        if (building == null) return;
         if (!tiles.TryGetValue(pos, out var tile)) return;
 
-        GameObject preview = new GameObject($"Preview_{building}");
+        GameObject preview = new GameObject($"Preview_{building.Code}");
         preview.transform.SetParent(tile.transform);
         preview.transform.localPosition = new Vector3(-0.5f, .7f, -0.25f);
         preview.transform.localScale = Vector3.one * 0.35f;
-        float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
-        if (building == BuildingCodes.Bridge) yRot = 0f; // don't rotate bridge
+        float yRot = building.ShouldRotate ? (building.Orientation == Orientation.Horizontal ? 0f : 90f) : 0f;
         preview.transform.localRotation = Quaternion.Euler(-32, yRot, 32);
 
         var renderer = preview.AddComponent<SpriteRenderer>();
-        string key = building == BuildingCodes.Bridge
-            ? $"{building}_{(orientation == Orientation.Horizontal ? "H" : "V")}"
-            : $"{building}_{level}";
+        string key = building.SpriteKey;
         renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.color = new Color(1f, 1f, 1f, 0.4f); // semitransparente
         renderer.sortingOrder = 8;
@@ -307,13 +305,14 @@ public class MapLoader : MonoBehaviour
             tile.AddComponent<TileActionProvider>();
 
             ApplyTerrain(tile, cell.terrain);
-            ApplyBuilding(tile, cell.building, cell.level);
-
-            AddFog(tile, coord);
-
             var buildingObj = BuildingFactory.Create(cell.building, cell.level);
             if (buildingObj != null)
+            {
+                ApplyBuilding(tile, buildingObj);
                 MapState.buildings[coord] = buildingObj;
+            }
+
+            AddFog(tile, coord);
 
             tiles[coord] = tile;
 
@@ -373,22 +372,19 @@ public class MapLoader : MonoBehaviour
             spriteRenderer.sprite = defaultSprite;
        
     }
-    void ApplyBuilding(GameObject tile, string building, int level, Orientation orientation = Orientation.Horizontal)
+    void ApplyBuilding(GameObject tile, Building building)
     {
-        if (string.IsNullOrEmpty(building)) return;
+        if (building == null) return;
 
-        GameObject buildingIcon = new GameObject($"Building_{building}");
+        GameObject buildingIcon = new GameObject($"Building_{building.Code}");
         buildingIcon.transform.SetParent(tile.transform);
         buildingIcon.transform.localPosition = new Vector3(0, 1f, -0.25f);
         buildingIcon.transform.localScale = Vector3.one * 0.45f;
-        float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
-        if (building == BuildingCodes.Bridge) yRot = 0f; // don't rotate bridge
+        float yRot = building.ShouldRotate ? (building.Orientation == Orientation.Horizontal ? 0f : 90f) : 0f;
         buildingIcon.transform.localRotation = Quaternion.Euler(-90, yRot - 30f, 40);
-        buildingIcon.tag = building;
+        buildingIcon.tag = building.Code;
         var renderer = buildingIcon.AddComponent<SpriteRenderer>();
-        string key = building == BuildingCodes.Bridge
-            ? $"{building}_{(orientation == Orientation.Horizontal ? "H" : "V")}"
-            : $"{building}_{level}";
+        string key = building.SpriteKey;
         renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.sortingOrder = 10;
 
@@ -426,44 +422,43 @@ public class MapLoader : MonoBehaviour
             );
         }
     }
-    public void DrawBuilding(Vector2Int pos, string building, int level, Orientation orientation = Orientation.Horizontal)
+    public void DrawBuilding(Vector2Int pos, Building building)
     {
+        if (building == null) return;
         if (!tiles.TryGetValue(pos, out var tile)) return;
 
-        GameObject buildingIcon = new GameObject($"Building_{building}");
+        GameObject buildingIcon = new GameObject($"Building_{building.Code}");
         buildingIcon.transform.SetParent(tile.transform);
         buildingIcon.transform.localPosition = new Vector3(-0.5f, .7f, -0.25f);
         buildingIcon.transform.localScale = Vector3.one * 0.35f;
-        float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
-        if (building == BuildingCodes.Bridge) yRot = 0f; // don't rotate bridge
+        float yRot = building.ShouldRotate ? (building.Orientation == Orientation.Horizontal ? 0f : 90f) : 0f;
         buildingIcon.transform.localRotation = Quaternion.Euler(-32, yRot, 32);
 
         var renderer = buildingIcon.AddComponent<SpriteRenderer>();
-        string key = building == BuildingCodes.Bridge
-            ? $"{building}_{(orientation == Orientation.Horizontal ? "H" : "V")}"
-            : $"{building}_{level}";
+        string key = building.SpriteKey;
         renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.sortingOrder = 10;
-
-        var obj = BuildingFactory.Create(building, level);
-        if (obj != null)
-            MapState.buildings[pos] = obj;
     }
 
     public void UpdateBuildingOrientation(Vector2Int pos, Orientation orientation)
     {
         if (!tiles.TryGetValue(pos, out var tile)) return;
+
+        MapState.buildings.TryGetValue(pos, out var building);
+        if (building != null)
+            building.Orientation = orientation;
+
         foreach (Transform child in tile.transform)
         {
             if (child.name.StartsWith("Building_"))
             {
-                float yRot = orientation == Orientation.Horizontal ? 0f : 90f;
-                if (child.tag == BuildingCodes.Bridge) yRot = 0f; // don't rotate bridge
+                float yRot = (building != null && !building.ShouldRotate) ? 0f :
+                    (orientation == Orientation.Horizontal ? 0f : 90f);
                 child.localRotation = Quaternion.Euler(-32, yRot, 32);
 
-                if (child.tag == BuildingCodes.Bridge && child.TryGetComponent<SpriteRenderer>(out var rend))
+                if (building != null && !building.ShouldRotate && child.TryGetComponent<SpriteRenderer>(out var rend))
                 {
-                    string key = $"{child.tag}_{(orientation == Orientation.Horizontal ? "H" : "V")}";
+                    string key = building.SpriteKey;
                     if (buildingSprites.ContainsKey(key))
                         rend.sprite = buildingSprites[key];
                 }
@@ -635,22 +630,22 @@ public class MapLoader : MonoBehaviour
         Debug.Log($"Edificio en {pos} ha sido demolido.");
     }
 
-    public void UpgradeBuilding(Vector2Int pos, string newBuilding, int level)
+    public void UpgradeBuilding(Vector2Int pos, Building newBuilding)
     {
+        if (newBuilding == null) return;
         if (!MapState.cellMap.TryGetValue(pos, out var cell))
             return;
 
         string old = cell.building;
-        cell.building = newBuilding;
-        cell.level = level;
+        cell.building = newBuilding.Code;
+        cell.level = newBuilding.Level;
         GameState.DecrementBuilding(old);
-        GameState.IncrementBuilding(newBuilding);
+        GameState.IncrementBuilding(newBuilding.Code);
         Orientation orient = Orientation.Horizontal;
         if (MapState.buildings.TryGetValue(pos, out var existing))
             orient = existing.Orientation;
-        MapState.buildings[pos] = BuildingFactory.Create(newBuilding, level);
-        if (MapState.buildings[pos] != null)
-            MapState.buildings[pos].Orientation = orient;
+        newBuilding.Orientation = orient;
+        MapState.buildings[pos] = newBuilding;
 
         if (tiles.TryGetValue(pos, out var tile))
         {
@@ -664,11 +659,11 @@ public class MapLoader : MonoBehaviour
             }
         }
 
-        DrawBuilding(pos, newBuilding, level, orient);
+        DrawBuilding(pos, newBuilding);
         if (MapState.buildings.TryGetValue(pos, out var b) &&
             (PlayerManager.Instance == null || PlayerManager.Instance.IsHumanPlayer(cell.owner)))
             RevealRadius(pos, b.VisibilityRadius);
-        Debug.Log($"Edificio en {pos} actualizado de {old} a {newBuilding}");
+        Debug.Log($"Edificio en {pos} actualizado de {old} a {newBuilding.Code}");
     }
 
 


### PR DESCRIPTION
## Summary
- add `ShouldRotate` and `SpriteKey` to `Building`
- override bridge behaviour to avoid rotations
- refactor `MapLoader` APIs to accept `Building` objects
- update character build preview and build logic
- upgrade actions now create `Building` instances

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a1ec0feec8333b16b12c06b7dfea7