### PR TITLE
Add attack action for enemy selections

### DIFF
--- a/Assets/Script/Actions/TileActionProvider.cs
+++ b/Assets/Script/Actions/TileActionProvider.cs
@@ -28,6 +28,12 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
 
         if (!string.IsNullOrEmpty(cell.building))
         {
+            if (!string.IsNullOrEmpty(cell.owner) && cell.owner != "player1")
+            {
+                player.AddAction(new ControlPanelAction("Atacar", () => Debug.Log("Atacando...")));
+                return;
+            }
+
             Vector2Int posCell = new(cell.x, cell.y);
             if (MapState.buildings.TryGetValue(posCell, out var building))
             {

--- a/Assets/Script/UI/ControlPanel.cs
+++ b/Assets/Script/UI/ControlPanel.cs
@@ -68,7 +68,16 @@ public class ControlPanel : MonoBehaviour
             title.text = character.name;
             buttons.Clear();
             character.ProvideInfo(GamePlayer.Instance);
-            character.ProposeActions(GamePlayer.Instance);
+
+            if (!string.IsNullOrEmpty(character.owner) && character.owner != "player1")
+            {
+                GamePlayer.Instance.AddAction(new ControlPanelAction("Atacar", () => Debug.Log("Atacando...")));
+            }
+            else
+            {
+                character.ProposeActions(GamePlayer.Instance);
+            }
+
             foreach (var infoItem in GamePlayer.Instance.GetInfo())
             {
                 AddInfoLabel(infoItem);


### PR DESCRIPTION
## Summary
- show only an **Atacar** option when selecting rival characters
- show only an **Atacar** option when selecting rival buildings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a333eceec8333a3cc7dfafd2ce604