### PR TITLE
Handle blocked routes during gathering

### DIFF
--- a/Assets/Script/Characters/Character.cs
+++ b/Assets/Script/Characters/Character.cs
@@ -163,10 +163,19 @@ public void AssignBuildTask(Vector2Int pos, string building)
             return;
         }
 
-    
+        Vector2Int next = currentPath.Peek();
+        if (!MapState.cellMap.TryGetValue(next, out var cell) ||
+            !Pathfinder.IsWalkable(cell.terrain, cell.building, cell.owner, owner))
+        {
+            AbortGatherRoute();
+            PlanGatherRoute();
+            return;
+        }
+
+        currentPath.Dequeue();
+
         animator.SetWalking(true);
 
-        Vector2Int next = currentPath.Dequeue();
         MoveTo(GridUtils.GridToWorld(next));
     }
 
@@ -448,6 +457,15 @@ public void AssignBuildTask(Vector2Int pos, string building)
         currentPath = null;
         moving = false;
         gatherRoute = null;
+    }
+
+    void AbortGatherRoute()
+    {
+        currentTask = Task.None;
+        currentPath = null;
+        gatherRoute = null;
+        moving = false;
+        animator?.SetWalking(false);
     }
 
     public void ProposeActions(GamePlayer player)


### PR DESCRIPTION
## Summary
- add a routine for aborting a gather route
- check for new obstacles before moving to the next tile
- stop movement and replan if the next step becomes unwalkable

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a3c02831c8333b612c79231ac07ba