### PR TITLE
Implement basic combat foundations

### DIFF
--- a/Assets/Script/Characters/WarriorRole.cs
+++ b/Assets/Script/Characters/WarriorRole.cs
@@ -4,6 +4,10 @@ public class WarriorRole : CharacterRole
 {
     public override string Code => "warrior";
 
+    public WarriorClass warriorClass = WarriorClass.SoldadoRaso;
+
+    public WarriorStats Stats => WarriorStatsMatrix.stats[warriorClass];
+
     public override void ProposeActions(Character character, GamePlayer player)
     {
         player.AddAction(new ControlPanelAction("Atacar", () =>

--- a/Assets/Script/Characters/WarriorStats.cs
+++ b/Assets/Script/Characters/WarriorStats.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+public enum WeaponType { None, Arrow, Bullet, Ray }
+public enum WarriorClass { SoldadoRaso, Arquero, Tanque, Elite, Destructor }
+
+public class WarriorStats
+{
+    public int shortRangeDamage;
+    public int longRangeDamage;
+    public WeaponType weapon;
+
+    public WarriorStats(int shortDmg, int longDmg, WeaponType weap)
+    {
+        shortRangeDamage = shortDmg;
+        longRangeDamage = longDmg;
+        weapon = weap;
+    }
+}
+
+public static class WarriorStatsMatrix
+{
+    public static readonly Dictionary<WarriorClass, WarriorStats> stats = new()
+    {
+        { WarriorClass.SoldadoRaso, new WarriorStats(2, 0, WeaponType.None) },
+        { WarriorClass.Arquero,     new WarriorStats(2, 2, WeaponType.Arrow) },
+        { WarriorClass.Tanque,      new WarriorStats(4, 3, WeaponType.Bullet) },
+        { WarriorClass.Elite,       new WarriorStats(5, 4, WeaponType.Bullet) },
+        { WarriorClass.Destructor,  new WarriorStats(6, 6, WeaponType.Ray) },
+    };
+}

--- a/Assets/Script/Characters/WarriorStats.cs.meta
+++ b/Assets/Script/Characters/WarriorStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e58f1a846db747079b9a99f2a6c7707e

--- a/Assets/Script/World/Buildings/Building.cs
+++ b/Assets/Script/World/Buildings/Building.cs
@@ -42,6 +42,26 @@ public abstract class Building
     public virtual string SpriteKey => $"{Code}_{Level}";
 
     /// <summary>
+    /// Hit points for the structure. If it reaches 0 the building is destroyed.
+    /// </summary>
+    public virtual int MaxResistance => 10;
+
+    /// <summary>
+    /// Damage dealt at long range. Non combat buildings can return 0.
+    /// </summary>
+    public virtual int RangedDamage => 0;
+
+    /// <summary>
+    /// Type of projectile used by the structure.
+    /// </summary>
+    public virtual WeaponType RangedWeapon => WeaponType.Arrow;
+
+    /// <summary>
+    /// Range for the long distance attack.
+    /// </summary>
+    public virtual int AttackRange => 3;
+
+    /// <summary>
     /// Acciones habilitadas en este nivel.
     /// </summary>
     public abstract IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell);

--- a/Assets/Script/World/Buildings/BuildingDefinitions.cs
+++ b/Assets/Script/World/Buildings/BuildingDefinitions.cs
@@ -223,6 +223,8 @@ public class AtalayaLevel1 : Building
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 20 };
     public override int VisibilityRadius => 3 + Level;
+    public override int RangedDamage => 4;
+    public override WeaponType RangedWeapon => WeaponType.Arrow;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 4 disparos por segundo" );
 }
 
@@ -231,6 +233,7 @@ public class AtalayaLevel2 : AtalayaLevel1
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40 };
     public override int VisibilityRadius => 3 + Level;
+    public override int RangedDamage => 8;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 8 disparos por segundo" );
 }
 
@@ -239,6 +242,7 @@ public class AtalayaLevel3 : AtalayaLevel2
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 60 };
     public override int VisibilityRadius => 3 + Level;
+    public override int RangedDamage => 16;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 16 disparos por segundo" );
 }
 
@@ -247,6 +251,7 @@ public class AtalayaLevel4 : AtalayaLevel3
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 80 };
     public override int VisibilityRadius => 3 + Level;
+    public override int RangedDamage => 32;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "Defensa 32 disparos por segundo" );
 }
 #endregion
@@ -257,6 +262,7 @@ public class WallLevel1 : Building
     public override string Code => BuildingCodes.Wall;
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement { wood = 10 };
+    public override int MaxResistance => 10;
 
     public override bool ShouldRotate => false;
     public override string SpriteKey => $"{Code}_{Level}_{(Orientation == Orientation.Horizontal ? "H" : "V")}";
@@ -268,6 +274,7 @@ public class WallLevel2 : WallLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 20 };
+    public override int MaxResistance => 20;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "resistencia 20" );
 }
 
@@ -275,6 +282,7 @@ public class WallLevel3 : WallLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 30 };
+    public override int MaxResistance => 30;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "resistencia 30" );
 }
 
@@ -282,6 +290,7 @@ public class WallLevel4 : WallLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 40 };
+    public override int MaxResistance => 40;
     public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "resistencia 40" );
 }
 #endregion

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -396,6 +396,10 @@ public class MapLoader : MonoBehaviour
         renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.sortingOrder = 10;
 
+        var health = buildingIcon.AddComponent<StructureHealth>();
+        var pos = new Vector2Int(Mathf.RoundToInt(tile.transform.position.x), Mathf.RoundToInt(tile.transform.position.z));
+        health.Initialize(pos, building.MaxResistance);
+
     }
 
     void DrawTrees(GameObject tile, int treeCount)
@@ -446,6 +450,9 @@ public class MapLoader : MonoBehaviour
         string key = building.SpriteKey;
         renderer.sprite = buildingSprites.ContainsKey(key) ? buildingSprites[key] : defaultBuildingSprite;
         renderer.sortingOrder = 10;
+
+        var health = buildingIcon.AddComponent<StructureHealth>();
+        health.Initialize(pos, building.MaxResistance);
     }
 
     public void UpdateBuildingOrientation(Vector2Int pos, Orientation orientation)
@@ -587,7 +594,9 @@ public class MapLoader : MonoBehaviour
             animator.southSprites = warriorSouthSprites;
             animator.eastSprites = warriorEastSprites;
             animator.westSprites = warriorWestSprites;
-            role = go.AddComponent<WarriorRole>();
+            var wr = go.AddComponent<WarriorRole>();
+            wr.warriorClass = WarriorClass.SoldadoRaso;
+            role = wr;
         }
         character.LoadSprites(new Dictionary<string, Sprite[]>
             {

--- a/Assets/Script/World/StructureHealth.cs
+++ b/Assets/Script/World/StructureHealth.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public class StructureHealth : MonoBehaviour
+{
+    public int maxResistance = 10;
+    public int currentResistance;
+    public Vector2Int gridPosition;
+
+    void Awake()
+    {
+        currentResistance = maxResistance;
+    }
+
+    public void Initialize(Vector2Int pos, int maxRes)
+    {
+        gridPosition = pos;
+        maxResistance = maxRes;
+        currentResistance = maxResistance;
+    }
+
+    public void TakeDamage(int amount)
+    {
+        currentResistance -= amount;
+        currentResistance = Mathf.Max(currentResistance, 0);
+        Debug.Log($"{name} recibio {amount} de daño. Resistencia actual: {currentResistance}");
+        if (currentResistance == 0)
+            DestroyStructure();
+    }
+
+    void DestroyStructure()
+    {
+        Debug.Log($"{name} ha sido destruido.");
+        if (MapLoader.instance != null)
+            MapLoader.instance.DemolishBuilding(gridPosition);
+        else
+            Destroy(gameObject);
+    }
+}

--- a/Assets/Script/World/StructureHealth.cs.meta
+++ b/Assets/Script/World/StructureHealth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc79ff1482bd4f7bb041b2512deacb1c


### PR DESCRIPTION
## Summary
- add `WarriorStats` table and `WeaponType`/`WarriorClass` enums
- extend `WarriorRole` with warrior class and stats
- add `StructureHealth` component for buildings
- give buildings default resistance and ranged attack properties
- specify ranged damage for Atalaya and resistance for Wall levels
- attach `StructureHealth` when placing buildings
- default new warriors to `SoldadoRaso`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688ab98c9f0c8333ae623ec2d1d525d5