### PR TITLE
Add save/load options to Temporal Breach

### DIFF
--- a/Assets/Script/Actions/BuildingActionHelper.cs
+++ b/Assets/Script/Actions/BuildingActionHelper.cs
@@ -18,6 +18,10 @@ public static class BuildingActionHelper
                 yield return SpawnCharacter(label, cell, Character.Type.Warrior);
             else if (lower.Contains("pedir recursos"))
                 yield return RequestResources(label);
+            else if (lower.Contains("grabar estado"))
+                yield return SaveState(label);
+            else if (lower.Contains("recuperar"))
+                yield return ShowLoadMenu(label);
             else
                 yield return NotImplemented(label);
         }
@@ -40,6 +44,16 @@ public static class BuildingActionHelper
             GameState.playerResources.wood += 10;
             Debug.Log("Recursos otorgados");
         });
+    }
+
+    public static ControlPanelAction SaveState(string label)
+    {
+        return new ControlPanelAction(label, () => SaveSystem.SaveGame());
+    }
+
+    public static ControlPanelAction ShowLoadMenu(string label)
+    {
+        return new ControlPanelAction(label, () => ControlPanel.Instance.ShowLoadMenu());
     }
 
     public static void SpawnCharacterNear(MapCellDTO cell, Character.Type type)

--- a/Assets/Script/Managers/GameResources.cs
+++ b/Assets/Script/Managers/GameResources.cs
@@ -1,3 +1,4 @@
+[System.Serializable]
 public class GameResources
 {
     public int gold = 100;

--- a/Assets/Script/Managers/SaveSystem.cs
+++ b/Assets/Script/Managers/SaveSystem.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using static DTO;
+
+[System.Serializable]
+public class GameSaveData
+{
+    public List<MapCellDTO> cells;
+    public GameResources resources;
+    public int year;
+    public int month;
+}
+
+public static class SaveSystem
+{
+    private static string SaveFolder => Path.Combine(Application.persistentDataPath, "saves");
+
+    public static void SaveGame()
+    {
+        Directory.CreateDirectory(SaveFolder);
+        GameSaveData data = new GameSaveData
+        {
+            cells = new List<MapCellDTO>(MapState.cellMap.Values),
+            resources = GameState.playerResources,
+            year = GameTimeManager.CurrentYear,
+            month = GameTimeManager.CurrentMonth
+        };
+        string json = JsonUtility.ToJson(data, true);
+        string path = Path.Combine(SaveFolder, DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".json");
+        File.WriteAllText(path, json);
+        Debug.Log($"Game saved to {path}");
+    }
+
+    public static string[] GetSavedFiles()
+    {
+        if (!Directory.Exists(SaveFolder))
+            return Array.Empty<string>();
+        return Directory.GetFiles(SaveFolder, "*.json");
+    }
+
+    public static void LoadGame(string path)
+    {
+        if (!File.Exists(path))
+        {
+            Debug.LogError($"Save not found: {path}");
+            return;
+        }
+        string json = File.ReadAllText(path);
+        var data = JsonUtility.FromJson<GameSaveData>(json);
+        if (data == null)
+        {
+            Debug.LogError("Invalid save file");
+            return;
+        }
+        MapState.cellMap = new Dictionary<Vector2Int, MapCellDTO>();
+        foreach (var cell in data.cells)
+            MapState.cellMap[new Vector2Int(cell.x, cell.y)] = cell;
+        GameState.playerResources = data.resources ?? new GameResources();
+        GameTimeManager.CurrentYear = data.year;
+        GameTimeManager.CurrentMonth = data.month;
+        Debug.Log($"Game loaded from {path}");
+    }
+}

--- a/Assets/Script/UI/ControlPanel.cs
+++ b/Assets/Script/UI/ControlPanel.cs
@@ -5,6 +5,7 @@ using UnityEngine.UIElements;
 using static Character;
 using static DTO;
 using GameConstants;
+using System.IO;
 
 
 public class ControlPanel : MonoBehaviour
@@ -16,6 +17,7 @@ public class ControlPanel : MonoBehaviour
     private VisualElement info;
     private VisualElement resourceInfo;
     public static ControlPanel Instance { get; private set; }
+    private GameObject currentSelection;
 
     private Label goldLabel;
     private Label woodLabel;
@@ -59,6 +61,7 @@ public class ControlPanel : MonoBehaviour
     }
     void UpdatePanel(GameObject selected)
     {
+        currentSelection = selected;
         info.Clear();
         resourceInfo?.Clear();
         GamePlayer.Instance.Clear();
@@ -164,6 +167,23 @@ public class ControlPanel : MonoBehaviour
         blocker.RegisterCallback<ClickEvent>(evt => evt.StopPropagation());
 
         root.Insert(0, blocker); // al fondo para no cubrir los controles
+    }
+
+    public void ShowLoadMenu()
+    {
+        buttons.Clear();
+        info.Clear();
+        title.text = "Cargar estado";
+        foreach (var file in SaveSystem.GetSavedFiles())
+        {
+            string path = file;
+            AddButton(Path.GetFileNameWithoutExtension(file), () =>
+            {
+                SaveSystem.LoadGame(path);
+                UpdatePanel(currentSelection);
+            });
+        }
+        AddButton("Cancelar", () => UpdatePanel(currentSelection));
     }
 
     void UpdateResourceLabels()

--- a/Assets/Script/World/Buildings/BuildingDefinitions.cs
+++ b/Assets/Script/World/Buildings/BuildingDefinitions.cs
@@ -417,7 +417,8 @@ public class TemporalBreach : Building
     public override string Code => BuildingCodes.TemporalBreach;
     public override int Level => 1;
     public override BuildRequirement Cost => new BuildRequirement();
-    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) 
-        => BuildingActionHelper.FromLabels(cell, "pedir recursos");
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell)
+        => BuildingActionHelper.FromLabels(cell,
+            "pedir recursos", "grabar estado", "recuperar");
 }
 #endregion


### PR DESCRIPTION
## Summary
- add `SaveSystem` helper for writing and loading game snapshots
- mark `GameResources` as serializable
- extend `ControlPanel` with load menu and remember selection
- add actions `grabar estado` and `recuperar` in building action helper
- expose new actions from `TemporalBreach` building

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ca2af8f9c8333b0dca120e0e21782