### PR TITLE
Fix map reload after loading save

### DIFF
--- a/Assets/Script/Managers/SaveSystem.cs
+++ b/Assets/Script/Managers/SaveSystem.cs
@@ -61,5 +61,8 @@ public static class SaveSystem
         GameTimeManager.CurrentYear = data.year;
         GameTimeManager.CurrentMonth = data.month;
         Debug.Log($"Game loaded from {path}");
+
+        if (MapLoader.instance != null)
+            MapLoader.instance.ReloadFromState();
     }
 }

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -386,6 +386,24 @@ public class MapLoader : MonoBehaviour
         Camera.main.transform.LookAt(center); // Apunta al centro del mapa
 
     }
+
+    public void ReloadFromState()
+    {
+        if (mapParent == null) return;
+
+        foreach (Transform child in mapParent)
+        {
+            Destroy(child.gameObject);
+        }
+
+        tiles.Clear();
+        MapState.buildings.Clear();
+
+        var cells = new List<MapCellDTO>(MapState.cellMap.Values);
+        GenerateGrid(cells);
+        CenterCamera(cells);
+        PlayerManager.Instance?.InitializePlayers();
+    }
     public bool IsPositionFree(Vector2Int pos)
     {
         // 1. Que exista el tile


### PR DESCRIPTION
## Summary
- regenerate map visuals after loading a saved game

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: `dotnet` not installed)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688caddadf048333b791ac5c8589dc09