### PR TITLE
Save fog and character data

### DIFF
--- a/Assets/Script/Managers/SaveSystem.cs
+++ b/Assets/Script/Managers/SaveSystem.cs
@@ -11,6 +11,8 @@ public class GameSaveData
     public GameResources resources;
     public int year;
     public int month;
+    public List<Vec2IntDTO> explored;
+    public List<CharacterDTO> characters;
 }
 
 public static class SaveSystem
@@ -25,8 +27,28 @@ public static class SaveSystem
             cells = new List<MapCellDTO>(MapState.cellMap.Values),
             resources = GameState.playerResources,
             year = GameTimeManager.CurrentYear,
-            month = GameTimeManager.CurrentMonth
+            month = GameTimeManager.CurrentMonth,
+            explored = new List<Vec2IntDTO>(),
+            characters = new List<CharacterDTO>()
         };
+
+        foreach (var pos in MapState.exploredCells)
+            data.explored.Add(new Vec2IntDTO(pos.x, pos.y));
+
+        foreach (var character in GameObject.FindObjectsOfType<Character>())
+        {
+            Vector2Int p = character.GetGridPosition();
+            string type = character.characterType.ToString();
+            if (character.role != null)
+                type = character.role.Code;
+            data.characters.Add(new CharacterDTO
+            {
+                x = p.x,
+                y = p.y,
+                type = type,
+                owner = character.owner
+            });
+        }
         string json = JsonUtility.ToJson(data, true);
         string path = Path.Combine(SaveFolder, DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".json");
         File.WriteAllText(path, json);
@@ -60,9 +82,40 @@ public static class SaveSystem
         GameState.playerResources = data.resources ?? new GameResources();
         GameTimeManager.CurrentYear = data.year;
         GameTimeManager.CurrentMonth = data.month;
+        MapState.exploredCells = new HashSet<Vector2Int>();
+        if (data.explored != null)
+        {
+            foreach (var pos in data.explored)
+                MapState.exploredCells.Add(new Vector2Int(pos.x, pos.y));
+        }
         Debug.Log($"Game loaded from {path}");
 
         if (MapLoader.instance != null)
+        {
             MapLoader.instance.ReloadFromState();
+            foreach (var ch in GameObject.FindObjectsOfType<Character>())
+                GameObject.Destroy(ch.gameObject);
+            if (data.characters != null)
+            {
+                foreach (var c in data.characters)
+                {
+                    Character.Type type;
+                    if (System.Enum.TryParse(c.type, out type))
+                        MapLoader.instance.SpawnCharacter(new Vector2Int(c.x, c.y), type, c.owner);
+                    else
+                    {
+                        if (c.type == "worker" || c.type == "scientist" || c.type == "warrior")
+                        {
+                            if (c.type == "worker") type = Character.Type.Worker;
+                            else if (c.type == "scientist") type = Character.Type.Scientist;
+                            else type = Character.Type.Warrior;
+                            MapLoader.instance.SpawnCharacter(new Vector2Int(c.x, c.y), type, c.owner);
+                        }
+                    }
+                }
+            }
+            foreach (var pos in MapState.exploredCells)
+                MapLoader.instance.RevealTile(pos);
+        }
     }
 }

--- a/Assets/Script/World/DTO.cs
+++ b/Assets/Script/World/DTO.cs
@@ -30,6 +30,28 @@ public class DTO
         public List<MapCellDTO> cells;
     }
 
+    [System.Serializable]
+    public struct Vec2IntDTO
+    {
+        public int x;
+        public int y;
+
+        public Vec2IntDTO(int x, int y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    [System.Serializable]
+    public class CharacterDTO
+    {
+        public int x;
+        public int y;
+        public string type;
+        public string owner;
+    }
+
    
     public List<Sprite> treeSprites;
     void DrawResourceIcon(GameObject tile, string resource, Sprite icon)


### PR DESCRIPTION
## Summary
- store explored fog tiles and character placement in `GameSaveData`
- include fog and character data when saving
- reload fog state and character positions when loading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cb081e904833380789bf264cda36b