### PR TITLE
Display science resource and space resource icons

### DIFF
--- a/Assets/Script/UI/ControlPanel.cs
+++ b/Assets/Script/UI/ControlPanel.cs
@@ -26,6 +26,7 @@ public class ControlPanel : MonoBehaviour
     private Label workerLabel;
     private Label soldierLabel;
     private Label scientistLabel;
+    private Label scienceLabel;
     private Label dateLabel;
     public bool freeResource = false;
 
@@ -44,6 +45,7 @@ public class ControlPanel : MonoBehaviour
         workerLabel = root.Q<Label>("WorkerLabel");
         soldierLabel = root.Q<Label>("SoldierLabel");
         scientistLabel = root.Q<Label>("ScientistLabel");
+        scienceLabel = root.Q<Label>("ScienceLabel");
         dateLabel = uiDocument.rootVisualElement.Q<Label>("DateLabel");
         if (resourceInfo != null)
         {
@@ -208,6 +210,7 @@ public class ControlPanel : MonoBehaviour
         if (woodLabel != null) woodLabel.text = res.wood.ToString();
         if (foodLabel != null) foodLabel.text = res.food.ToString();
         if (cronoLabel != null) cronoLabel.text = res.crono.ToString();
+        if (scienceLabel != null) scienceLabel.text = res.science.ToString();
         var characters = GameObject.FindObjectsOfType<Character>();
         int workers = characters.Count(c => c.characterType == Character.Type.Worker);
         int soldiers = characters.Count(c => c.characterType == Character.Type.Warrior);

--- a/Assets/UI Toolkit/ControlPanel.uss
+++ b/Assets/UI Toolkit/ControlPanel.uss
@@ -90,13 +90,16 @@
     font-size: 12px;
     color: white;
     text-align: center;
+    background-color: rgba(255, 255, 255, 0.1);
+    padding: 0 2px;
 }
 .gold-icon { background-image: resource("Icons/gold"); }
 .resources-panel {
     flex-direction: row;
     flex-wrap: wrap;
-    width: 110px;
-    gap: 4px;
+    flex-grow: 0;
+    width: 220px;
+    gap: 8px;
 }
 .wood-icon { background-image: resource("Icons/wood"); }
 .food-icon { background-image: resource("Icons/food"); }
@@ -104,3 +107,4 @@
 .worker-icon { background-image: resource("Icons/worker"); }
 .soldier-icon { background-image: resource("Icons/soldier"); }
 .scientist-icon { background-image: resource("Icons/scientist"); }
+.science-icon { background-image: resource("Icons/science"); }

--- a/Assets/UI Toolkit/ControlPanel.uxml
+++ b/Assets/UI Toolkit/ControlPanel.uxml
@@ -33,6 +33,10 @@
                 <ui:VisualElement class="resource-icon scientist-icon" />
                 <ui:Label name="ScientistLabel" text="0/0" />
             </ui:VisualElement>
+            <ui:VisualElement class="resource-box">
+                <ui:VisualElement class="resource-icon science-icon" />
+                <ui:Label name="ScienceLabel" text="0" />
+            </ui:VisualElement>
         </ui:VisualElement>
         <ui:VisualElement name="buttons" class="panel-column buttons-panel" />
         <ui:VisualElement name="info" class="panel-column info-panel" />


### PR DESCRIPTION
## Summary
- Organize resource display in a grid with spacing and toned quantity backgrounds
- Show new science resource alongside existing ones
- Remove large science icon asset from repository

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d879f30d88333bafdcbce47c805b0