### PR TITLE
Display building sprite icons for actions

### DIFF
--- a/Assets/Script/Actions/ControlPanelAction.cs
+++ b/Assets/Script/Actions/ControlPanelAction.cs
@@ -1,12 +1,16 @@
 using System;
+using UnityEngine;
 
 public class ControlPanelAction
 {
     public string label;
     public Action callback;
-    public ControlPanelAction(string label, Action callback)
+    public Sprite icon;
+
+    public ControlPanelAction(string label, Action callback, Sprite icon = null)
     {
         this.label = label;
         this.callback = callback;
+        this.icon = icon;
     }
 }

--- a/Assets/Script/Actions/TileActionProvider.cs
+++ b/Assets/Script/Actions/TileActionProvider.cs
@@ -45,6 +45,8 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
             {
                 if (ControlPanel.Instance.freeResource || GameState.playerResources.science >= evo.requiredScience)
                 {
+                    var upgradeBuilding = BuildingFactory.Create(evo.next, evo.level);
+                    var icon = upgradeBuilding != null ? MapLoader.instance.GetBuildingSprite(upgradeBuilding.SpriteKey) : null;
                     player.AddAction(new ControlPanelAction($"Mejorar a {evo.next}", () =>
                     {
                         var req = BuildRules.GetRequirements(evo.next);
@@ -58,7 +60,7 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
                         var newBuilding = BuildingFactory.Create(evo.next, evo.level);
                         MapLoader.instance.UpgradeBuilding(new Vector2Int(cell.x, cell.y), newBuilding);
                         GameEvents.RaiseSelection(gameObject);
-                    }));
+                    }, icon));
                 }
             }
 
@@ -76,9 +78,10 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
 
         void TryBuild(string text, string code)
         {
+            var building = BuildingFactory.Create(code);
+            var req = building != null ? building.Cost : new BuildRequirement();
+            var icon = building != null ? MapLoader.instance.GetBuildingSprite(building.SpriteKey) : null;
             player.AddAction(new ControlPanelAction(text, () => {
-                var building = BuildingFactory.Create(code);
-                var req = building != null ? building.Cost : new BuildRequirement();
                 if (!ControlPanel.Instance.freeResource)
                 {
                     if (!GameState.playerResources.HasEnough(req))
@@ -95,20 +98,22 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
                     GameState.playerResources.Consume(req);
                     ActionManager.Instance.Enqueue(new BuildAction(worker, pos, code));
                 }
-            }));
+            }, icon));
         }
 
         if (terrainBuildings.TryGetValue(cell.terrain, out var options))
         {
             if (cell.terrain == TerrainTypes.Forest && !TownhallExists())
             {
+                var townhall = BuildingFactory.Create(BuildingCodes.Townhall);
+                var iconTown = townhall != null ? MapLoader.instance.GetBuildingSprite(townhall.SpriteKey) : null;
                 player.AddAction(new ControlPanelAction("Construir casa central", () => {
                     var worker = FindFreeWorker();
                     if (worker != null)
                         ActionManager.Instance.Enqueue(new BuildAction(worker, new Vector2Int(cell.x, cell.y), BuildingCodes.Townhall));
                     else
                         Debug.Log("No hay obreros disponibles.");
-                }));
+                }, iconTown));
             }
             else
             {

--- a/Assets/Script/UI/ControlPanel.cs
+++ b/Assets/Script/UI/ControlPanel.cs
@@ -96,7 +96,7 @@ public class ControlPanel : MonoBehaviour
             }
             foreach (var act in GamePlayer.Instance.GetActions())
             {
-                AddButton(act.label, act.callback);
+                AddButton(act);
             }
         }
 
@@ -119,7 +119,7 @@ public class ControlPanel : MonoBehaviour
             tileProvider.ProposeActions(GamePlayer.Instance);
             foreach (var act in GamePlayer.Instance.GetActions())
             {
-                AddButton(act.label, act.callback);
+                AddButton(act);
             }
             return;
         }
@@ -140,17 +140,34 @@ public class ControlPanel : MonoBehaviour
 
     void AddButton(string text, Action onClick)
     {
+        AddButton(new ControlPanelAction(text, onClick));
+    }
+
+    void AddButton(ControlPanelAction action)
+    {
         var button = new Button(() =>
         {
             var selected = CharacterController.instance.SelectedCharacter;
             if (selected != null)
                 selected.CancelCurrentTask();
 
-            onClick();
-        })
-        { text = text };
-        button.pickingMode = PickingMode.Position;
+            action.callback();
+        });
 
+        if (action.icon != null)
+        {
+            button.text = string.Empty;
+            button.style.backgroundImage = new StyleBackground(action.icon);
+            button.tooltip = action.label;
+            button.style.width = 64;
+            button.style.height = 64;
+        }
+        else
+        {
+            button.text = action.label;
+        }
+
+        button.pickingMode = PickingMode.Position;
         buttons.Add(button);
     }
 

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -159,6 +159,13 @@ public class MapLoader : MonoBehaviour
         return null;
     }
 
+    public Sprite GetBuildingSprite(string key)
+    {
+        if (buildingSprites != null && buildingSprites.TryGetValue(key, out var s))
+            return s;
+        return defaultBuildingSprite;
+    }
+
 
     void Start()
     {


### PR DESCRIPTION
## Summary
- Add optional sprite to `ControlPanelAction` and render it on control panel buttons
- Provide building sprite icons for build and upgrade options

## Testing
- `dotnet test` *(command not found)*
- `apt-get update` *(repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d90f590a08333bb648a5cbd45c1aa