### PR TITLE
Use bomb icon for demolition action

### DIFF
--- a/Assets/Script/Actions/TileActionProvider.cs
+++ b/Assets/Script/Actions/TileActionProvider.cs
@@ -8,6 +8,7 @@ using GameConstants;
 public class TileActionProvider : MonoBehaviour, IActionProposer
 {
     TileClickHandler handler;
+    static Sprite demolishIcon;
 
     static readonly System.Collections.Generic.Dictionary<string, string[]> terrainBuildings = new()
     {
@@ -19,6 +20,8 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
     void Awake()
     {
         handler = GetComponent<TileClickHandler>();
+        if (demolishIcon == null)
+            demolishIcon = Resources.Load<Sprite>("Icons/bomb");
     }
 
     public void ProposeActions(GamePlayer player)
@@ -69,7 +72,7 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
                 player.AddAction(new ControlPanelAction("Derrumbar", () => {
                     MapLoader.instance.DemolishBuilding(new Vector2Int(cell.x, cell.y));
                     GameEvents.RaiseSelection(gameObject);
-                }));
+                }, demolishIcon));
             }
             return;
         }


### PR DESCRIPTION
## Summary
- show a bomb icon when triggering the Derrumbar action

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d95abf03083338fc2b7344647ed8d