### PR TITLE
Show unit icons on creation buttons

### DIFF
--- a/Assets/Script/Actions/BuildingActionHelper.cs
+++ b/Assets/Script/Actions/BuildingActionHelper.cs
@@ -29,7 +29,21 @@ public static class BuildingActionHelper
 
     public static ControlPanelAction SpawnCharacter(string label, MapCellDTO cell, Character.Type type)
     {
-        return new ControlPanelAction(label, () => SpawnCharacterNear(cell, type));
+        Sprite icon = null;
+        switch (type)
+        {
+            case Character.Type.Worker:
+                icon = Resources.Load<Sprite>("Icons/worker");
+                break;
+            case Character.Type.Scientist:
+                icon = Resources.Load<Sprite>("Icons/scientist");
+                break;
+            case Character.Type.Warrior:
+                icon = Resources.Load<Sprite>("Icons/soldier");
+                break;
+        }
+
+        return new ControlPanelAction(label, () => SpawnCharacterNear(cell, type), icon);
     }
 
     public static ControlPanelAction NotImplemented(string label)


### PR DESCRIPTION
## Summary
- Load sprites for worker, scientist, and soldier when building actions spawn units
- Display these sprites on their respective control panel buttons

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688da16c035483338a41dccec0e6f199