### PR TITLE
Implement building-level resource multipliers

### DIFF
--- a/Assets/Script/Managers/GameTimeManager.cs
+++ b/Assets/Script/Managers/GameTimeManager.cs
@@ -48,6 +48,8 @@ public class GameTimeManager : MonoBehaviour
         int farmCount = 0;
         int mineCount = 0;
         int lumberCount = 0;
+        float farmMultiplier = 0f;
+        float lumberMultiplier = 0f;
 
         foreach (var cell in MapState.cellMap.Values)
         {
@@ -58,12 +60,14 @@ public class GameTimeManager : MonoBehaviour
             {
                 case BuildingCodes.Farm:
                     farmCount++;
+                    farmMultiplier += ResourceProductionMatrix.GetMultiplier(BuildingCodes.Farm, cell.level);
                     break;
                 case BuildingCodes.Mine:
                     mineCount++;
                     break;
                 case BuildingCodes.Lumbermill:
                     lumberCount++;
+                    lumberMultiplier += ResourceProductionMatrix.GetMultiplier(BuildingCodes.Lumbermill, cell.level);
                     break;
                 default:
                     total += ResourceProductionMatrix.GetFlow(cell.building);
@@ -157,14 +161,16 @@ public class GameTimeManager : MonoBehaviour
         {
             int effective = Mathf.Min(woodWorkers, lumberCount * workersPerBuilding);
             float groups = effective / (float)workersPerBuilding;
-            total += ResourceProductionMatrix.GetFlow(BuildingCodes.Lumbermill).Scale(groups);
+            float avgMultiplier = lumberMultiplier / lumberCount;
+            total += ResourceProductionMatrix.GetFlow(BuildingCodes.Lumbermill).Scale(groups * avgMultiplier);
         }
 
         if (farmCount > 0)
         {
             int effective = Mathf.Min(foodWorkers, farmCount * workersPerBuilding);
             float groups = effective / (float)workersPerBuilding;
-            total += ResourceProductionMatrix.GetFlow(BuildingCodes.Farm).Scale(groups);
+            float avgMultiplier = farmMultiplier / farmCount;
+            total += ResourceProductionMatrix.GetFlow(BuildingCodes.Farm).Scale(groups * avgMultiplier);
         }
 
         GameState.playerResources.AddFlow(total);

--- a/Assets/Script/World/ResourceProductionMatrix.cs
+++ b/Assets/Script/World/ResourceProductionMatrix.cs
@@ -17,6 +17,18 @@ public static class ResourceProductionMatrix
         { "warrior", new ResourceFlow(food: -2) },
     };
 
+    public static readonly Dictionary<(string, int), float> levelMultipliers = new()
+    {
+        { (BuildingCodes.Lumbermill, 1), 1f },
+        { (BuildingCodes.Lumbermill, 2), 2f },
+        { (BuildingCodes.Lumbermill, 3), 3f },
+        { (BuildingCodes.Lumbermill, 4), 4f },
+        { (BuildingCodes.Farm, 1), 1f },
+        { (BuildingCodes.Farm, 2), 2f },
+        { (BuildingCodes.Farm, 3), 3f },
+        { (BuildingCodes.Farm, 4), 4f },
+    };
+
     public static ResourceFlow GetFlow(string code)
     {
         return production.TryGetValue(code, out var flow) ? flow : new ResourceFlow();
@@ -25,5 +37,10 @@ public static class ResourceProductionMatrix
     public static ResourceFlow GetFlow(CharacterRole role)
     {
         return GetFlow(role.Code);
+    }
+
+    public static float GetMultiplier(string code, int level)
+    {
+        return levelMultipliers.TryGetValue((code, level), out var mult) ? mult : 1f;
     }
 }


### PR DESCRIPTION
## Summary
- Multiply farm food output by level-based multipliers
- Multiply lumbermill wood output by level-based multipliers
- Add lookup for building level multipliers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688df707bcc48333bc3673cb516ce9cc