### PR TITLE
Allow selecting automatic workers when no idle workers for construction

### DIFF
--- a/Assets/Script/Actions/TileActionProvider.cs
+++ b/Assets/Script/Actions/TileActionProvider.cs
@@ -134,24 +134,25 @@ public class TileActionProvider : MonoBehaviour, IActionProposer
     Character FindFreeWorker()
     {
         var all = GameObject.FindObjectsOfType<Character>();
+
+        // Primero buscar un obrero que no esté realizando ninguna tarea
         foreach (var c in all)
         {
-            if (c.role is WorkerRole &&
-                c.controlMode == Character.ControlMode.Automatic &&
-                c.currentTask == Character.Task.None)
+            if (c.role is WorkerRole && c.currentTask == Character.Task.None)
             {
                 return c;
             }
         }
+
+        // Si no hay obreros libres, tomar cualquiera en modo automático
         foreach (var c in all)
         {
-            if (c.role is WorkerRole &&
-                c.controlMode == Character.ControlMode.Manual &&
-                c.currentTask == Character.Task.None)
+            if (c.role is WorkerRole && c.controlMode == Character.ControlMode.Automatic)
             {
                 return c;
             }
         }
+
         return null;
     }
 


### PR DESCRIPTION
## Summary
- When searching for a worker to build, prefer idle workers first and, if none are idle, pick an automatically controlled worker.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dfa60426883338fca974852875137