### PR TITLE
Add timeline slider for time-travel observation mode

### DIFF
--- a/Assets/Script/Managers/GameTimeManager.cs
+++ b/Assets/Script/Managers/GameTimeManager.cs
@@ -20,6 +20,8 @@ public class GameTimeManager : MonoBehaviour
 
     public static event System.Action<int, int> OnDateChanged;
 
+    private bool observationMode = false;
+
     void Awake()
     {
         Instance = this;
@@ -197,11 +199,16 @@ public class GameTimeManager : MonoBehaviour
 
     public bool Approve(ControlPanelAction action)
     {
-        return true; // placeholder for time-based rules
+        return !observationMode;
     }
 
     public bool Approve(InfoItem info)
     {
-        return true; // placeholder for time-based rules
+        return !observationMode;
+    }
+
+    public void SetObservationMode(bool value)
+    {
+        observationMode = value;
     }
 }

--- a/Assets/Script/Managers/TimelineManager.cs
+++ b/Assets/Script/Managers/TimelineManager.cs
@@ -119,7 +119,22 @@ public class TimelineManager : MonoBehaviour
         return -1;
     }
 
-    public List<WorldEvent> GetWorldStateAt(float time)
+    GameResources CloneResources(GameResources src)
+    {
+        return new GameResources
+        {
+            gold = src.gold,
+            wood = src.wood,
+            food = src.food,
+            crono = src.crono,
+            science = src.science,
+            freeHousing = src.freeHousing,
+            academicUnits = src.academicUnits,
+            barracksUnits = src.barracksUnits
+        };
+    }
+
+    public Snapshot GetWorldStateAt(float time)
     {
         Snapshot snap = null;
         for (int i = snapshots.Count - 1; i >= 0; i--)
@@ -130,13 +145,14 @@ public class TimelineManager : MonoBehaviour
                 break;
             }
         }
-        List<WorldEvent> events = new();
-        foreach (var e in globalEvents)
+        if (snap != null)
         {
-            if (e.timestamp > time) break;
-            events.Add(e);
+            MapState.cellMap = new Dictionary<Vector2Int, DTO.MapCellDTO>(snap.cells);
+            if (snap.resources.TryGetValue("player", out var res))
+                GameState.playerResources = CloneResources(res);
+            MapLoader.instance?.ReloadFromState();
         }
-        return events;
+        return snap;
     }
 
     public void SaveSnapshot()
@@ -144,8 +160,10 @@ public class TimelineManager : MonoBehaviour
         var snap = new Snapshot();
         snap.timestamp = Time.time;
         snap.cells = new Dictionary<Vector2Int, DTO.MapCellDTO>(MapState.cellMap);
-        snap.resources = new Dictionary<string, GameResources>();
-        // placeholder - deep copy resources if needed
+        snap.resources = new Dictionary<string, GameResources>
+        {
+            ["player"] = CloneResources(GameState.playerResources)
+        };
         snapshots.Add(snap);
     }
 }

--- a/Assets/Script/UI/TimelineControl.cs
+++ b/Assets/Script/UI/TimelineControl.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+public class TimelineControl : MonoBehaviour
+{
+    public UIDocument uiDocument;
+    private Slider slider;
+    private Button presentButton;
+    private bool inPast = false;
+
+    void OnEnable()
+    {
+        if (uiDocument == null) return;
+        var root = uiDocument.rootVisualElement;
+        slider = root.Q<Slider>("TimelineSlider");
+        presentButton = root.Q<Button>("PresentButton");
+        if (slider != null)
+        {
+            slider.lowValue = 0f;
+            slider.highValue = Time.time;
+            slider.SetValueWithoutNotify(Time.time);
+            slider.RegisterValueChangedCallback(OnSliderChanged);
+        }
+        if (presentButton != null)
+            presentButton.clicked += ReturnToPresent;
+    }
+
+    void Update()
+    {
+        if (!inPast && slider != null)
+        {
+            slider.highValue = Time.time;
+            slider.SetValueWithoutNotify(Time.time);
+        }
+    }
+
+    void OnSliderChanged(ChangeEvent<float> evt)
+    {
+        float t = evt.newValue;
+        TimelineManager.Instance?.GetWorldStateAt(t);
+        bool past = t < Time.time;
+        if (past != inPast)
+        {
+            inPast = past;
+            GameTimeManager.Instance?.SetObservationMode(inPast);
+        }
+    }
+
+    void ReturnToPresent()
+    {
+        inPast = false;
+        GameTimeManager.Instance?.SetObservationMode(false);
+        if (slider != null)
+        {
+            slider.highValue = Time.time;
+            slider.SetValueWithoutNotify(Time.time);
+        }
+        TimelineManager.Instance?.GetWorldStateAt(Time.time);
+    }
+}

--- a/Assets/Script/UI/TimelineControl.cs.meta
+++ b/Assets/Script/UI/TimelineControl.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 529efd52fffe4593be96359313a9c067

--- a/Assets/UI Toolkit/TimelinePanel.uss
+++ b/Assets/UI Toolkit/TimelinePanel.uss
@@ -1,0 +1,13 @@
+.timeline-root {
+    position: absolute;
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+}
+
+#TimelineSlider {
+    flex-grow: 1;
+}

--- a/Assets/UI Toolkit/TimelinePanel.uss.meta
+++ b/Assets/UI Toolkit/TimelinePanel.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11d5e9e8be9d451c9b2953e6517a41af
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Assets/UI Toolkit/TimelinePanel.uxml
+++ b/Assets/UI Toolkit/TimelinePanel.uxml
@@ -1,0 +1,7 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" editor-extension-mode="True">
+    <Style src="project://database/Assets/UI%20Toolkit/TimelinePanel.uss?fileID=7433441132597879392&guid=11d5e9e8be9d451c9b2953e6517a41af&type=3#TimelinePanel" />
+    <ui:VisualElement name="timeline-root" class="timeline-root">
+        <ui:Slider name="TimelineSlider" />
+        <ui:Button name="PresentButton" text="Volver al Presente" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/UI Toolkit/TimelinePanel.uxml.meta
+++ b/Assets/UI Toolkit/TimelinePanel.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1d17b02a0dc14e02bf1939eaa5f589c6
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
## Summary
- Implement TimelineManager snapshot cloning and restoration to rebuild map and resources at any timestamp.
- Add observation mode in GameTimeManager to block actions while exploring past states.
- Introduce TimelineControl UI with slider and "Volver al Presente" button using a new UXML panel.

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e7e7a281c8333b5e1e9102c153789