### PR TITLE
Fix slider visibility in control panel

### DIFF
--- a/Assets/UI Toolkit/ControlPanel.uss
+++ b/Assets/UI Toolkit/ControlPanel.uss
@@ -52,7 +52,7 @@
     align-items: flex-start;
 }
 
-.buttons-panel > * {
+.buttons-panel > .unity-button {
     margin-right: 4px;
     margin-bottom: 4px;
     flex-grow: 0;


### PR DESCRIPTION
## Summary
- Restrict button-specific styles so that they don't override sliders, allowing breach request slider to display and expand

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e86a95b208333a763f8222248077a