### PR TITLE
Adjust timeline slider handle width

### DIFF
--- a/Assets/Script/UI/TimelineControl.cs
+++ b/Assets/Script/UI/TimelineControl.cs
@@ -22,6 +22,7 @@ public class TimelineControl : MonoBehaviour
             GameTimeManager.UpdateDateFromSeconds(Time.time);
             slider.label = $"Mes {GameTimeManager.CurrentMonth} - Año {GameTimeManager.CurrentYear}";
             slider.RegisterValueChangedCallback(OnSliderChanged);
+            slider.RegisterCallback<GeometryChangedEvent>(_ => UpdateSliderHandle());
         }
         if (presentButton != null)
             presentButton.clicked += ReturnToPresent;
@@ -34,6 +35,7 @@ public class TimelineControl : MonoBehaviour
             slider.highValue = Time.time;
             slider.SetValueWithoutNotify(Time.time);
             slider.label = $"Mes {GameTimeManager.CurrentMonth} - Año {GameTimeManager.CurrentYear}";
+            UpdateSliderHandle();
         }
     }
 
@@ -61,7 +63,24 @@ public class TimelineControl : MonoBehaviour
             slider.SetValueWithoutNotify(Time.time);
             GameTimeManager.UpdateDateFromSeconds(Time.time);
             slider.label = $"Mes {GameTimeManager.CurrentMonth} - Año {GameTimeManager.CurrentYear}";
+            UpdateSliderHandle();
         }
         TimelineManager.Instance?.GetWorldStateAt(Time.time);
+    }
+
+    void UpdateSliderHandle()
+    {
+        if (slider == null) return;
+        var dragger = slider.Q(className: "unity-dragger");
+        if (dragger == null) return;
+
+        float totalSeconds = slider.highValue - slider.lowValue;
+        if (totalSeconds <= 0f) return;
+
+        float monthSeconds = GameTimeManager.SecondsPerMonth;
+        float ratio = monthSeconds / totalSeconds;
+        float width = slider.resolvedStyle.width * ratio;
+        if (width < 1f) width = 1f;
+        dragger.style.width = width;
     }
 }


### PR DESCRIPTION
## Summary
- scale timeline slider handle according to month length
- ensure handle width never drops below one pixel

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_688ee533bae88333b2e1c26df1e23e5c