### PR TITLE
Avoid excessive timeline snapshots

### DIFF
--- a/Assets/Script/Managers/GameTimeManager.cs
+++ b/Assets/Script/Managers/GameTimeManager.cs
@@ -53,9 +53,12 @@ public class GameTimeManager : MonoBehaviour
             return;
 
         SecondsToDate(seconds, out var month, out var year);
+        bool changed = month != CurrentMonth || year != CurrentYear;
         CurrentMonth = month;
         CurrentYear = year;
-        OnDateChanged?.Invoke(CurrentMonth, CurrentYear);
+
+        if (!Instance.observationMode && changed)
+            OnDateChanged?.Invoke(CurrentMonth, CurrentYear);
     }
 
     void Awake()

--- a/Assets/Script/Managers/TimelineManager.cs
+++ b/Assets/Script/Managers/TimelineManager.cs
@@ -182,6 +182,12 @@ public class TimelineManager : MonoBehaviour
         snapshots.Add(snap);
     }
 
+    public void RemoveLastSnapshot()
+    {
+        if (snapshots.Count > 0)
+            snapshots.RemoveAt(snapshots.Count - 1);
+    }
+
     public List<Snapshot> GetSnapshots()
     {
         return new List<Snapshot>(snapshots);

--- a/Assets/Script/UI/TimelineControl.cs
+++ b/Assets/Script/UI/TimelineControl.cs
@@ -8,6 +8,8 @@ public class TimelineControl : MonoBehaviour
     private Button presentButton;
     private VisualElement tickContainer;
     private bool inPast = false;
+    private int backupMonth;
+    private int backupYear;
 
     void OnEnable()
     {
@@ -69,7 +71,11 @@ public class TimelineControl : MonoBehaviour
         if (past)
         {
             if (!inPast)
+            {
                 TimelineManager.Instance?.SaveSnapshot();
+                backupMonth = GameTimeManager.CurrentMonth;
+                backupYear = GameTimeManager.CurrentYear;
+            }
 
             var snaps = TimelineManager.Instance?.GetSnapshots();
             Snapshot nearest = null;
@@ -102,8 +108,19 @@ public class TimelineControl : MonoBehaviour
         else
         {
             TimelineManager.Instance?.GetWorldStateAt(Time.time);
-            GameTimeManager.UpdateDateFromSeconds(Time.time);
-            slider.label = FormatTimeLabel(Time.time);
+            if (inPast)
+            {
+                TimelineManager.Instance?.RemoveLastSnapshot();
+                GameTimeManager.UpdateDateFromSeconds(Time.time);
+                slider.label = FormatTimeLabel(Time.time);
+                if (GameTimeManager.CurrentMonth == backupMonth && GameTimeManager.CurrentYear == backupYear)
+                    TimelineManager.Instance?.SaveSnapshot();
+            }
+            else
+            {
+                GameTimeManager.UpdateDateFromSeconds(Time.time);
+                slider.label = FormatTimeLabel(Time.time);
+            }
             GameTimeManager.Instance?.SetObservationMode(false);
             inPast = false;
         }
@@ -114,19 +131,26 @@ public class TimelineControl : MonoBehaviour
 
     void ReturnToPresent()
     {
-        inPast = false;
+        if (inPast)
+        {
+            TimelineManager.Instance?.GetWorldStateAt(Time.time);
+            TimelineManager.Instance?.RemoveLastSnapshot();
+            GameTimeManager.Instance?.SetObservationMode(false);
+            GameTimeManager.UpdateDateFromSeconds(Time.time);
+            if (GameTimeManager.CurrentMonth == backupMonth && GameTimeManager.CurrentYear == backupYear)
+                TimelineManager.Instance?.SaveSnapshot();
+        }
         GameTimeManager.Instance?.SetObservationMode(false);
         if (slider != null)
         {
             int now = Mathf.RoundToInt(Time.time);
             slider.highValue = now;
             slider.SetValueWithoutNotify(now);
-            GameTimeManager.UpdateDateFromSeconds(now);
             slider.label = FormatTimeLabel(now);
             UpdateSliderHandle();
             DrawMonthTicks();
         }
-        TimelineManager.Instance?.GetWorldStateAt(Time.time);
+        inPast = false;
     }
 
     void UpdateSliderHandle()
@@ -200,7 +224,7 @@ public class TimelineControl : MonoBehaviour
 
     string FormatTimeLabel(float seconds)
     {
-        GameTimeManager.UpdateDateFromSeconds(seconds);
-        return $"M{GameTimeManager.CurrentMonth} - A{GameTimeManager.CurrentYear}";
+        GameTimeManager.SecondsToDate(seconds, out var month, out var year);
+        return $"M{month} - A{year}";
     }
 }


### PR DESCRIPTION
## Summary
- Only dispatch date changes when month transitions and not during observation
- Add ability to remove latest timeline snapshot and restore one when returning to the present
- Rework timeline control to manage backups and compute labels without side effects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689095881e6c83339810d279ee404f42