### PR TITLE
Fix character state when scrubbing timeline

### DIFF
--- a/Assets/Script/Managers/SaveSystem.cs
+++ b/Assets/Script/Managers/SaveSystem.cs
@@ -22,6 +22,7 @@ public class SnapshotDTO
     public float timestamp;
     public List<MapCellDTO> cells;
     public List<SnapshotResourceDTO> resources;
+    public List<CharacterDTO> characters;
 }
 
 [System.Serializable]
@@ -75,11 +76,17 @@ public static class SaveSystem
                 {
                     timestamp = snap.timestamp,
                     cells = new List<MapCellDTO>(snap.cells.Values),
-                    resources = new List<SnapshotResourceDTO>()
+                    resources = new List<SnapshotResourceDTO>(),
+                    characters = new List<CharacterDTO>()
                 };
                 foreach (var kv in snap.resources)
                 {
                     sDto.resources.Add(new SnapshotResourceDTO { id = kv.Key, resources = kv.Value });
+                }
+                if (snap.characters != null)
+                {
+                    foreach (var c in snap.characters)
+                        sDto.characters.Add(new CharacterDTO { x = c.x, y = c.y, type = c.type, owner = c.owner });
                 }
                 data.snapshots.Add(sDto);
             }
@@ -134,7 +141,8 @@ public static class SaveSystem
                     {
                         timestamp = sDto.timestamp,
                         cells = new Dictionary<Vector2Int, MapCellDTO>(),
-                        resources = new Dictionary<string, GameResources>()
+                        resources = new Dictionary<string, GameResources>(),
+                        characters = new List<CharacterDTO>()
                     };
                     if (sDto.cells != null)
                     {
@@ -145,6 +153,11 @@ public static class SaveSystem
                     {
                         foreach (var r in sDto.resources)
                             snap.resources[r.id] = r.resources;
+                    }
+                    if (sDto.characters != null)
+                    {
+                        foreach (var c in sDto.characters)
+                            snap.characters.Add(new CharacterDTO { x = c.x, y = c.y, type = c.type, owner = c.owner });
                     }
                     snaps.Add(snap);
                 }

--- a/Assets/Script/Managers/TimelineManager.cs
+++ b/Assets/Script/Managers/TimelineManager.cs
@@ -25,6 +25,7 @@ public class Snapshot
     public float timestamp;
     public Dictionary<Vector2Int, DTO.MapCellDTO> cells;
     public Dictionary<string, GameResources> resources;
+    public List<DTO.CharacterDTO> characters;
 }
 
 public class TimelineManager : MonoBehaviour
@@ -167,6 +168,35 @@ public class TimelineManager : MonoBehaviour
             if (snap.resources.TryGetValue("player", out var res))
                 GameState.playerResources = CloneResources(res);
             MapLoader.instance?.ReloadFromState();
+
+            if (MapLoader.instance != null)
+            {
+                foreach (var ch in GameObject.FindObjectsOfType<Character>())
+                    GameObject.Destroy(ch.gameObject);
+
+                if (snap.characters != null)
+                {
+                    foreach (var c in snap.characters)
+                    {
+                        var pos = new Vector2Int(c.x, c.y);
+                        Character.Type type;
+                        if (System.Enum.TryParse(c.type, out type))
+                        {
+                            MapLoader.instance.SpawnCharacter(pos, type, c.owner);
+                        }
+                        else
+                        {
+                            if (c.type == "worker" || c.type == "scientist" || c.type == "warrior")
+                            {
+                                if (c.type == "worker") type = Character.Type.Worker;
+                                else if (c.type == "scientist") type = Character.Type.Scientist;
+                                else type = Character.Type.Warrior;
+                                MapLoader.instance.SpawnCharacter(pos, type, c.owner);
+                            }
+                        }
+                    }
+                }
+            }
         }
         return snap;
     }
@@ -177,7 +207,7 @@ public class TimelineManager : MonoBehaviour
         int currentMonth = GameTimeManager.CurrentMonth;
         int currentYear = GameTimeManager.CurrentYear;
 
-        // Buscar índice del snapshot existente para este año/mes
+        // Buscar Ã­ndice del snapshot existente para este aÃ±o/mes
         int existingIndex = -1;
         
         if (!force)
@@ -186,6 +216,22 @@ public class TimelineManager : MonoBehaviour
                 GameTimeManager.SecondsToDate(s.timestamp, out currentMonth, out currentYear);
                 return GameTimeManager.CurrentMonth == currentMonth && GameTimeManager.CurrentYear == currentYear;
             });
+
+        var charList = new List<DTO.CharacterDTO>();
+        foreach (var character in GameObject.FindObjectsOfType<Character>())
+        {
+            var p = character.GetGridPosition();
+            string type = character.characterType.ToString();
+            if (character.role != null)
+                type = character.role.Code;
+            charList.Add(new DTO.CharacterDTO
+            {
+                x = p.x,
+                y = p.y,
+                type = type,
+                owner = character.owner
+            });
+        }
 
         var snap = new Snapshot
         {
@@ -197,7 +243,8 @@ public class TimelineManager : MonoBehaviour
             resources = new Dictionary<string, GameResources>
             {
                 ["player"] = GameState.playerResources.Clone()
-            }
+            },
+            characters = charList
         };
 
         if (existingIndex >= 0)


### PR DESCRIPTION
## Summary
- include character data in timeline snapshots and reload them when seeking
- persist snapshot character data during save and load

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test` *(command not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d705edd48333a8b0c51f9b44f7fe