### PR TITLE
feat: centralize game time with GameClock

### DIFF
--- a/Assets/Script/Managers/GameClock.cs
+++ b/Assets/Script/Managers/GameClock.cs
@@ -1,0 +1,14 @@
+public static class GameClock
+{
+    public static float Time { get; private set; }
+
+    public static void Advance(float deltaTime)
+    {
+        Time += deltaTime;
+    }
+
+    public static void Set(float value)
+    {
+        Time = value;
+    }
+}

--- a/Assets/Script/Managers/GameTimeManager.cs
+++ b/Assets/Script/Managers/GameTimeManager.cs
@@ -75,6 +75,7 @@ public class GameTimeManager : MonoBehaviour
         if (observationMode)
             return;
 
+        GameClock.Advance(Time.deltaTime);
         timer += Time.deltaTime;
         if (timer >= interval)
         {

--- a/Assets/Script/Managers/SaveSystem.cs
+++ b/Assets/Script/Managers/SaveSystem.cs
@@ -9,6 +9,7 @@ public class GameSaveData
 {
     public List<MapCellDTO> cells;
     public GameResources resources;
+    public float time;
     public int year;
     public int month;
     public List<Vec2IntDTO> explored;
@@ -43,6 +44,7 @@ public static class SaveSystem
         {
             cells = new List<MapCellDTO>(MapState.cellMap.Values),
             resources = GameState.playerResources,
+            time = GameClock.Time,
             year = GameTimeManager.CurrentYear,
             month = GameTimeManager.CurrentMonth,
             explored = new List<Vec2IntDTO>(),
@@ -124,6 +126,8 @@ public static class SaveSystem
         GameState.playerResources = data.resources ?? new GameResources();
         GameTimeManager.CurrentYear = data.year;
         GameTimeManager.CurrentMonth = data.month;
+        GameClock.Set(data.time);
+        GameTimeManager.UpdateDateFromSeconds(GameClock.Time);
         MapState.exploredCells = new HashSet<Vector2Int>();
         if (data.explored != null)
         {

--- a/Assets/Script/Managers/TimelineManager.cs
+++ b/Assets/Script/Managers/TimelineManager.cs
@@ -81,7 +81,7 @@ public class TimelineManager : MonoBehaviour
         if (isTimeTraveling)
             return;
 
-        originalTime = Time.time;
+        originalTime = GameClock.Time;
         currentTimelineEvents = globalEvents
             .Where(e => e.timestamp <= originalTime)
             .ToList();
@@ -113,7 +113,7 @@ public class TimelineManager : MonoBehaviour
 
     public WorldEvent RecordEvent(string actorId, string action, Dictionary<string, string> parameters, List<int> deps = null, int? rngSeed = null)
     {
-        var ev = new WorldEvent(nextId++, Time.time, actorId, action);
+        var ev = new WorldEvent(nextId++, GameClock.Time, actorId, action);
         if (parameters != null)
         {
             foreach (var kv in parameters)
@@ -351,7 +351,7 @@ public class TimelineManager : MonoBehaviour
 
         var snap = new Snapshot
         {
-            timestamp = Time.time,
+            timestamp = GameClock.Time,
             cellDeltas = cellDeltas,
             resourceDeltas = resourceDeltas,
             characters = charList

--- a/Assets/Script/UI/TimelineControl.cs
+++ b/Assets/Script/UI/TimelineControl.cs
@@ -23,12 +23,12 @@ public class TimelineControl : MonoBehaviour
         if (slider != null)
         {
             slider.lowValue = 0;
-            slider.highValue = Mathf.RoundToInt(Time.time);
+            slider.highValue = Mathf.RoundToInt(GameClock.Time);
             slider.showInputField = false;
-            slider.SetValueWithoutNotify(Mathf.RoundToInt(Time.time));
+            slider.SetValueWithoutNotify(Mathf.RoundToInt(GameClock.Time));
 
-            GameTimeManager.UpdateDateFromSeconds(Time.time);
-            slider.label = FormatTimeLabel(Time.time);
+            GameTimeManager.UpdateDateFromSeconds(GameClock.Time);
+            slider.label = FormatTimeLabel(GameClock.Time);
 
             slider.RegisterValueChangedCallback(OnSliderChanged);
 
@@ -51,12 +51,12 @@ public class TimelineControl : MonoBehaviour
     {
         if (slider == null) return;
 
-        slider.highValue = Mathf.RoundToInt(Time.time);
+        slider.highValue = Mathf.RoundToInt(GameClock.Time);
 
         // 🔥 Solo auto-actualiza si NO estamos en el pasado
         if (!inPast)
         {
-            int now = Mathf.RoundToInt(Time.time);
+            int now = Mathf.RoundToInt(GameClock.Time);
             slider.SetValueWithoutNotify(now);
             GameTimeManager.UpdateDateFromSeconds(now);
             slider.label = FormatTimeLabel(now);
@@ -70,7 +70,7 @@ public class TimelineControl : MonoBehaviour
     {
         Debug.Log($"[Timeline] Cambió slider: {evt.newValue}");
         float t = evt.newValue;
-        bool past = t < Time.time - 0.1f; // margen pequeño
+        bool past = t < GameClock.Time - 0.1f; // margen pequeño
 
         if (past)
         {
@@ -91,17 +91,17 @@ public class TimelineControl : MonoBehaviour
         }
         else
         {
-            TimelineManager.Instance?.GetWorldStateAt(Time.time);
+            TimelineManager.Instance?.GetWorldStateAt(GameClock.Time);
             if (inPast)
             {
                 TimelineManager.Instance?.RemoveLastSnapshot();
-                GameTimeManager.UpdateDateFromSeconds(Time.time);
-                slider.label = FormatTimeLabel(Time.time);
+                GameTimeManager.UpdateDateFromSeconds(GameClock.Time);
+                slider.label = FormatTimeLabel(GameClock.Time);
             }
             else
             {
-                GameTimeManager.UpdateDateFromSeconds(Time.time);
-                slider.label = FormatTimeLabel(Time.time);
+                GameTimeManager.UpdateDateFromSeconds(GameClock.Time);
+                slider.label = FormatTimeLabel(GameClock.Time);
             }
             GameTimeManager.Instance?.SetObservationMode(false);
             inPast = false;
@@ -121,15 +121,15 @@ public class TimelineControl : MonoBehaviour
         TimelineManager.Instance?.FinishTimeTravel();
         if (inPast)
         {
-            TimelineManager.Instance?.GetWorldStateAt(Time.time);
+            TimelineManager.Instance?.GetWorldStateAt(GameClock.Time);
             TimelineManager.Instance?.RemoveLastSnapshot();
             GameTimeManager.Instance?.SetObservationMode(false);
-            GameTimeManager.UpdateDateFromSeconds(Time.time);
+            GameTimeManager.UpdateDateFromSeconds(GameClock.Time);
         }
         GameTimeManager.Instance?.SetObservationMode(false);
         if (slider != null)
         {
-            int now = Mathf.RoundToInt(Time.time);
+            int now = Mathf.RoundToInt(GameClock.Time);
             slider.highValue = now;
             slider.SetValueWithoutNotify(now);
             slider.label = FormatTimeLabel(now);


### PR DESCRIPTION
## Summary
- add static GameClock to maintain logical game time
- switch time references in timeline and managers to GameClock.Time
- persist GameClock time in save/load system

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891ef8a93508333b3cc24d5e29c5839