### PR TITLE
Add new barracks units and remove elite/destructor

### DIFF
--- a/Assets/Scenes/game.unity
+++ b/Assets/Scenes/game.unity
@@ -1008,7 +1008,7 @@ MonoBehaviour:
     - {fileID: 739907800, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
     - {fileID: 739907800, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
     - {fileID: 440698487, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
-  eliteSprites:
+  cyborSprites:
     north:
     - {fileID: -1146325917, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
     - {fileID: 477912563, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
@@ -1025,7 +1025,7 @@ MonoBehaviour:
     - {fileID: -1340127470, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
     - {fileID: -1863310492, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
     - {fileID: 1291912294, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
-  destructorSprites:
+  dronSprites:
     north:
     - {fileID: 1135083526, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}
     - {fileID: -674185064, guid: e587ef0ee1304a047b65c87a3df9df8e, type: 3}

--- a/Assets/Script/Actions/BuildingActionHelper.cs
+++ b/Assets/Script/Actions/BuildingActionHelper.cs
@@ -14,7 +14,7 @@ public static class BuildingActionHelper
                 yield return SpawnCharacter(label, cell, Character.Type.Worker);
             else if (lower.Contains("cientifico"))
                 yield return SpawnCharacter(label, cell, Character.Type.Scientist);
-            else if (lower.Contains("soldado"))
+            else if (lower.Contains("soldado") || lower.Contains("arquero") || lower.Contains("tanque") || lower.Contains("cybor") || lower.Contains("dron"))
                 yield return SpawnCharacter(label, cell, Character.Type.Warrior);
             else if (lower.Contains("grabar estado"))
                 yield return SaveState(label);
@@ -30,6 +30,7 @@ public static class BuildingActionHelper
     public static ControlPanelAction SpawnCharacter(string label, MapCellDTO cell, Character.Type type)
     {
         Sprite icon = null;
+        var lower = label.ToLowerInvariant();
         switch (type)
         {
             case Character.Type.Worker:
@@ -39,7 +40,16 @@ public static class BuildingActionHelper
                 icon = Resources.Load<Sprite>("Icons/scientist");
                 break;
             case Character.Type.Warrior:
-                icon = Resources.Load<Sprite>("Icons/soldier");
+                if (lower.Contains("arquero"))
+                    icon = Resources.Load<Sprite>("Icons/archer");
+                else if (lower.Contains("tanque"))
+                    icon = Resources.Load<Sprite>("Icons/tank");
+                else if (lower.Contains("cybor"))
+                    icon = Resources.Load<Sprite>("Icons/cybor");
+                else if (lower.Contains("dron"))
+                    icon = Resources.Load<Sprite>("Icons/dron");
+                else
+                    icon = Resources.Load<Sprite>("Icons/soldier");
                 break;
         }
 

--- a/Assets/Script/Characters/WarriorStats.cs
+++ b/Assets/Script/Characters/WarriorStats.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 
 public enum WeaponType { None, Arrow, Bullet, Ray }
-public enum WarriorClass { SoldadoRaso, Arquero, Tanque, Elite, Destructor }
+public enum WarriorClass { SoldadoRaso, Arquero, Tanque, Cybor, Dron }
 
 public class WarriorStats
 {
@@ -24,7 +24,7 @@ public static class WarriorStatsMatrix
         { WarriorClass.SoldadoRaso, new WarriorStats(2, 0, WeaponType.None) },
         { WarriorClass.Arquero,     new WarriorStats(2, 2, WeaponType.Arrow) },
         { WarriorClass.Tanque,      new WarriorStats(4, 3, WeaponType.Bullet) },
-        { WarriorClass.Elite,       new WarriorStats(5, 4, WeaponType.Bullet) },
-        { WarriorClass.Destructor,  new WarriorStats(6, 6, WeaponType.Ray) },
+        { WarriorClass.Cybor,       new WarriorStats(5, 4, WeaponType.Bullet) },
+        { WarriorClass.Dron,        new WarriorStats(6, 6, WeaponType.Ray) },
     };
 }

--- a/Assets/Script/World/Buildings/BuildingDefinitions.cs
+++ b/Assets/Script/World/Buildings/BuildingDefinitions.cs
@@ -55,21 +55,21 @@ public class BarracksLevel2 : BarracksLevel1
 {
     public override int Level => 2;
     public override BuildRequirement Cost => new BuildRequirement { wood = 60, gold = 30 };
-    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo tanque" );
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo arquero" );
 }
 
 public class BarracksLevel3 : BarracksLevel2
 {
     public override int Level => 3;
     public override BuildRequirement Cost => new BuildRequirement { wood = 90, gold = 60 };
-    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo tanque", "nuevo elite" );
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo arquero", "nuevo tanque" );
 }
 
 public class BarracksLevel4 : BarracksLevel3
 {
     public override int Level => 4;
     public override BuildRequirement Cost => new BuildRequirement { wood = 120, gold = 90 };
-    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo tanque", "nuevo elite", "nuevo destructor" );
+    public override IEnumerable<ControlPanelAction> GetActions(MapCellDTO cell) => BuildingActionHelper.FromLabels(cell, "nuevo soldado", "nuevo arquero", "nuevo tanque", "nuevo cybor", "nuevo dron" );
 }
 #endregion
 

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -115,8 +115,8 @@ public class MapLoader : MonoBehaviour
     public DirectionalSprites soldadoRasoSprites;
     public DirectionalSprites arqueroSprites;
     public DirectionalSprites tanqueSprites;
-    public DirectionalSprites eliteSprites;
-    public DirectionalSprites destructorSprites;
+    public DirectionalSprites cyborSprites;
+    public DirectionalSprites dronSprites;
 
     public Sprite arrowWeaponSprite;
     public Sprite bulletWeaponSprite;
@@ -140,8 +140,8 @@ public class MapLoader : MonoBehaviour
             { WarriorClass.SoldadoRaso, soldadoRasoSprites },
             { WarriorClass.Arquero, arqueroSprites },
             { WarriorClass.Tanque, tanqueSprites },
-            { WarriorClass.Elite, eliteSprites },
-            { WarriorClass.Destructor, destructorSprites }
+            { WarriorClass.Cybor, cyborSprites },
+            { WarriorClass.Dron, dronSprites }
         };
 
         weaponSpriteMap = new Dictionary<WeaponType, Sprite>

--- a/docs/building_evolutions.md
+++ b/docs/building_evolutions.md
@@ -9,9 +9,9 @@ Este documento detalla las acciones habilitadas en cada nivel de las distintas c
 | Townhall | 3 | nuevo obrero, nuevo marino, nuevo espia, nuevo experto |
 | Townhall | 4 | nuevo obrero, nuevo marino, nuevo espia, nuevo experto |
 | Barracas | 1 | nuevo soldado |
-| Barracas | 2 | nuevo soldado, nuevo tanque |
-| Barracas | 3 | nuevo soldado, nuevo tanque, nuevo elite |
-| Barracas | 4 | nuevo soldado, nuevo tanque, nuevo elite, nuevo destructor |
+| Barracas | 2 | nuevo soldado, nuevo arquero |
+| Barracas | 3 | nuevo soldado, nuevo arquero, nuevo tanque |
+| Barracas | 4 | nuevo soldado, nuevo arquero, nuevo tanque, nuevo cybor, nuevo dron |
 | Aeropuerto | 1 | nuevo avion |
 | Aeropuerto | 2 | nuevo avion, nuevo bombardero |
 | Puerto | 1 | nuevo pesquero |


### PR DESCRIPTION
## Summary
- Allow barracks to recruit archer at level 2, tank at level 3, and cybor/dron at level 4
- Replace elite and destructor unit types with cybor and dron, including sprites and stats
- Show icons for new warrior types in action buttons and update docs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68921da8def48333961f2b2956790571