### PR TITLE
Ensure building upgrades persist in timeline snapshots

### DIFF
--- a/Assets/Script/World/DTO.cs
+++ b/Assets/Script/World/DTO.cs
@@ -23,7 +23,9 @@ public class DTO
                 y = this.y,
                 terrain = this.terrain,
                 building = this.building,
+                level = this.level,
                 owner = this.owner,
+                start_player = this.start_player,
                 resources = this.resources != null ? this.resources.Clone() : null
             };
         }


### PR DESCRIPTION
## Summary
- Copy building level and starting owner when cloning map cells to preserve upgrades in timeline snapshots

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894cbde5f988333836627546fb31ff3