### PR TITLE
Fix snapshot baseline when viewing past state

### DIFF
--- a/Assets/Script/Managers/TimelineManager.cs
+++ b/Assets/Script/Managers/TimelineManager.cs
@@ -381,6 +381,9 @@ public class TimelineManager : MonoBehaviour
             ? CloneResources(res)
             : new GameResources();
 
+        lastSnapshotCells = world.cells.ToDictionary(kv => kv.Key, kv => kv.Value.Clone());
+        lastSnapshotResources = world.resources.ToDictionary(kv => kv.Key, kv => CloneResources(kv.Value));
+
         MapLoader.instance?.ReloadFromState();
 
         if (MapLoader.instance != null)


### PR DESCRIPTION
## Summary
- Refresh last snapshot caches when reconstructing past world states to prevent retroactive changes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68950daf4f6c83339f6a545f5767a197