### PR TITLE
Ensure base snapshot and clean time lookup

### DIFF
--- a/Assets/Script/Managers/TimelineManager.cs
+++ b/Assets/Script/Managers/TimelineManager.cs
@@ -651,20 +651,20 @@ public class TimelineManager : MonoBehaviour
             timeTravelStartTime = time;
 
         var orderedSnapshots = currentBranch.snapshots.OrderBy(s => s.timestamp).ToList();
-        bool anyApplied = false;
+        if (orderedSnapshots.Count == 0)
+            return world;
 
-        for (int i = 0; i < orderedSnapshots.Count; i++)
+        var first = orderedSnapshots[0];
+        if (time < first.timestamp)
         {
-            var snap = orderedSnapshots[i];
+            // No se puede viajar antes del inicio: fijamos el tiempo al primer snapshot
+            time = first.timestamp;
+        }
 
+        foreach (var snap in orderedSnapshots)
+        {
             if (snap.timestamp > time)
-            {
-                // Si aún no aplicamos ningún snapshot, usamos el primero
-                if (!anyApplied && orderedSnapshots.Count > 0)
-                    snap = orderedSnapshots[0];
-                else
-                    break;
-            }
+                break;
 
             if (snap.cellDeltas != null)
             {
@@ -680,27 +680,6 @@ public class TimelineManager : MonoBehaviour
 
             if (snap.characters != null)
                 chars = new List<DTO.CharacterDTO>(snap.characters);
-
-            anyApplied = true;
-        }
-
-        if (!anyApplied && orderedSnapshots.Count > 0)
-        {
-            var first = orderedSnapshots[0];
-            if (first.cellDeltas != null)
-            {
-                foreach (var kv in first.cellDeltas)
-                    world.cells[kv.Key] = kv.Value.Clone();
-            }
-
-            if (first.resourceDeltas != null)
-            {
-                foreach (var kv in first.resourceDeltas)
-                    world.resources[kv.Key] = CloneResources(kv.Value);
-            }
-
-            if (first.characters != null)
-                chars = new List<DTO.CharacterDTO>(first.characters);
         }
 
         MapState.cellMap = world.cells.ToDictionary(kv => kv.Key, kv => kv.Value.Clone());

--- a/Assets/Script/World/MapLoader.cs
+++ b/Assets/Script/World/MapLoader.cs
@@ -273,7 +273,10 @@ public class MapLoader : MonoBehaviour
         GenerateGrid(wrapper.cells);
         CenterCamera(wrapper.cells);
         PlayerManager.Instance?.InitializePlayers();
-      
+
+        // Force creation of the base snapshot once the initial world is ready
+        TimelineManager.Instance?.SaveSnapshot(true);
+
         yield return null;
     }
     public void ShowConstructionPreview(Vector2Int pos, Building building)


### PR DESCRIPTION
## Summary
- Save initial timeline snapshot after world generation
- Rework GetWorldStateAt to apply snapshots up to requested time and clamp time before start

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960bd308a48333a8f113f1a5c62c97