### PR TITLE
Limit timeline divisions to 12

### DIFF
--- a/Assets/Script/UI/TimelineControl.cs
+++ b/Assets/Script/UI/TimelineControl.cs
@@ -203,10 +203,35 @@ public class TimelineControl : MonoBehaviour
         int totalMonths = Mathf.CeilToInt(totalSeconds / GameTimeManager.SecondsPerMonth);
         float width = slider.resolvedStyle.width;
 
-        for (int i = 0; i <= totalMonths; i++)
+        int monthStep = Mathf.Max(1, Mathf.CeilToInt(totalMonths / 12f));
+
+        for (int m = 0; m <= totalMonths; m += monthStep)
         {
-            float x = (i / (float)totalMonths) * width;
-            float timeAtTick = slider.lowValue + (i * GameTimeManager.SecondsPerMonth);
+            float x = (m / (float)totalMonths) * width;
+            float timeAtTick = slider.lowValue + (m * GameTimeManager.SecondsPerMonth);
+
+            var tick = new VisualElement();
+            tick.style.position = Position.Absolute;
+            tick.style.left = x;
+            tick.style.bottom = 0;
+            tick.style.width = 2;
+            tick.style.height = 10;
+            tick.style.backgroundColor = Color.white;
+            tickContainer.Add(tick);
+
+            var label = new Label(FormatTimeLabel(timeAtTick));
+            label.style.position = Position.Absolute;
+            label.style.left = x - 12;
+            label.style.bottom = 12;
+            label.style.fontSize = 8;
+            label.style.color = Color.white;
+            tickContainer.Add(label);
+        }
+
+        if (totalMonths % monthStep != 0)
+        {
+            float x = width;
+            float timeAtTick = slider.highValue;
 
             var tick = new VisualElement();
             tick.style.position = Position.Absolute;


### PR DESCRIPTION
## Summary
- prevent more than 12 month divisions on the timeline slider
- dynamically adjust tick spacing based on total timeline length

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689810d53c248333b8b5300cfda0e1f7