### PR TITLE
Fix timeline rebuild losing original event timing

### DIFF
--- a/Assets/Script/Managers/TimelineManager.cs
+++ b/Assets/Script/Managers/TimelineManager.cs
@@ -329,8 +329,19 @@ public class TimelineManager : MonoBehaviour
         HashSet<int> invalid = new HashSet<int>();
         List<WorldEvent> survivors = new();
 
-        foreach (var ev in ordered)
+        int index = 0;
+        while (index < ordered.Count && ordered[index].timestamp <= baseSnapshot.timestamp)
         {
+            var ev = ordered[index++];
+            ev.wasApplied = true;
+            ev.failureReason = null;
+            applied.Add(ev.id);
+            survivors.Add(ev);
+        }
+
+        for (; index < ordered.Count; index++)
+        {
+            var ev = ordered[index];
             ev.wasApplied = false;
             ev.failureReason = null;
 
@@ -387,6 +398,15 @@ public class TimelineManager : MonoBehaviour
         HashSet<int> invalid = new HashSet<int>();
         List<WorldEvent> survivors = new();
         int idx = 0;
+
+        while (idx < ordered.Count && ordered[idx].timestamp <= baseSnapshot.timestamp)
+        {
+            var ev = ordered[idx++];
+            ev.wasApplied = true;
+            ev.failureReason = null;
+            applied.Add(ev.id);
+            survivors.Add(ev);
+        }
 
         float currentTime = baseSnapshot.timestamp;
         GameClock.Set(currentTime);


### PR DESCRIPTION
## Summary
- ensure events before the base snapshot are marked as already applied in branch rebuilds
- avoid reapplying early events when reconstructing history to prevent timeline compression

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e6787c548333998297b9106dd60a